### PR TITLE
Add logging field to backend-config of Edna

### DIFF
--- a/lib/common/edna/backend-config.nix
+++ b/lib/common/edna/backend-config.nix
@@ -11,4 +11,5 @@
       init-script = "/init.sql";
     };
   };
+  logging = "Dev";
 }


### PR DESCRIPTION
Problem: after recent changes edna-server's config file
has a mandatory key `logging`.
Solution: update `backend-config.nix` file to contain this
key. We set it to `Dev` for now.