### PR TITLE
[OPS-1138] Enable monitoring via wireguard for all nodes

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -3,6 +3,7 @@
     inputs.serokell-nix.nixosModules.common
     inputs.serokell-nix.nixosModules.serokell-users
     inputs.vault-secrets.nixosModules.vault-secrets
+    inputs.serokell-nix.nixosModules.wireguard-monitoring
   ];
 
   networking.domain = "gemini.serokell.team";

--- a/lib/common/edna/server.nix
+++ b/lib/common/edna/server.nix
@@ -6,7 +6,7 @@
     profile = "/nix/var/nix/profiles/per-user/deploy/edna-docker";
   in
   {
-    networking.firewall.allowedTCPPorts = [ 80 443 9100 ];
+    networking.firewall.allowedTCPPorts = [ 80 443 ];
 
     virtualisation.docker = {
       enable = true;

--- a/servers/alhena/default.nix
+++ b/servers/alhena/default.nix
@@ -7,7 +7,7 @@ in {
     inputs.hermetic.nixosModules.hermetic
   ];
 
-  networking.firewall.allowedTCPPorts = [ 80 443 9100 ];
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
 
   vault-secrets.secrets.hermetic.environmentVariableNamePrefix = "hermetic";
   services.hermetic = {
@@ -28,4 +28,5 @@ in {
   };
 
   networking.hostName = "alhena";
+  wireguard-ip-address = "172.21.0.9";
 }

--- a/servers/alzirr/default.nix
+++ b/servers/alzirr/default.nix
@@ -6,4 +6,5 @@
   ];
 
   networking.hostName = "alzirr";
+  wireguard-ip-address = "172.21.0.25";
 }

--- a/servers/castor/default.nix
+++ b/servers/castor/default.nix
@@ -36,4 +36,5 @@
     } ];
 
   networking.hostName = "castor";
+  wireguard-ip-address = "172.21.0.11";
 }

--- a/servers/jishui/default.nix
+++ b/servers/jishui/default.nix
@@ -36,4 +36,5 @@
     } ];
 
   networking.hostName = "jishui";
+  wireguard-ip-address = "172.21.0.12";
 }

--- a/servers/mekbuda/default.nix
+++ b/servers/mekbuda/default.nix
@@ -27,4 +27,5 @@
   };
 
   networking.hostName = "mekbuda";
+  wireguard-ip-address = "172.21.0.13";
 }

--- a/terraform/alhena.tf
+++ b/terraform/alhena.tf
@@ -9,9 +9,9 @@ resource "aws_instance" "alhena" {
   vpc_security_group_ids = [
     aws_security_group.egress_all.id,
     aws_security_group.mtg.id,
-    aws_security_group.prometheus_exporter_node.id,
     aws_security_group.ssh.id,
     aws_security_group.http.id,
+    aws_security_group.wireguard.id,
   ]
 
   # Instance parameters

--- a/terraform/castor.tf
+++ b/terraform/castor.tf
@@ -9,8 +9,8 @@ resource "aws_instance" "castor" {
   vpc_security_group_ids = [
     aws_security_group.egress_all.id,
     aws_security_group.http.id,
-    aws_security_group.prometheus_exporter_node.id,
     aws_security_group.ssh.id,
+    aws_security_group.wireguard.id,
   ]
 
   # Instance parameters

--- a/terraform/jishui.tf
+++ b/terraform/jishui.tf
@@ -9,8 +9,8 @@ resource "aws_instance" "jishui" {
   vpc_security_group_ids = [
     aws_security_group.egress_all.id,
     aws_security_group.http.id,
-    aws_security_group.prometheus_exporter_node.id,
     aws_security_group.ssh.id,
+    aws_security_group.wireguard.id,
   ]
 
   # Instance parameters

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,21 +59,6 @@ resource "aws_security_group" "egress_all" {
   }
 }
 
-# Allow traffic for the prometheus exporter
-resource "aws_security_group" "prometheus_exporter_node" {
-  name = "prometheus_exporter_node"
-  description = "Allow Prometheus Node Exporter data scraping"
-  vpc_id = module.vpc.vpc_id
-
-  ingress {
-    from_port = 9100
-    to_port = 9100
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
-}
-
 # Allow SSH traffic
 resource "aws_security_group" "ssh" {
   name = "ssh"
@@ -130,6 +115,21 @@ resource "aws_security_group" "mtg" {
     from_port = 3128
     to_port = 3128
     protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+# Allow wireguard traffic
+resource "aws_security_group" "wireguard" {
+  name = "ssh"
+  description = "Allow inbound and outbound traffic for wireguard"
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    from_port        = 51820
+    to_port          = 51820
+    protocol         = "udp"
     cidr_blocks = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }

--- a/terraform/mekbuda.tf
+++ b/terraform/mekbuda.tf
@@ -9,8 +9,8 @@ resource "aws_instance" "mekbuda" {
   vpc_security_group_ids = [
     aws_security_group.egress_all.id,
     aws_security_group.mtg.id,
-    aws_security_group.prometheus_exporter_node.id,
     aws_security_group.ssh.id,
+    aws_security_group.wireguard.id,
   ]
 
   # Instance parameters


### PR DESCRIPTION
Adds wireguard interface which connects each node to polis, and runs prometheus node exporter on that interface.

As I understand, mtg on mekbuda is not working yet (@balsoft correct me if I'm wrong), but we can still enable wireguard there, we just won't add it to prometheus until it's finished.