### PR TITLE
[EDNA-117] Fetch secrets for backend container from Vault

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1617871354,
-        "narHash": "sha256-3sCuJbCke12dnvude2nxk2isrGPdvZT3uM9A/fcb1Hs=",
+        "lastModified": 1620677945,
+        "narHash": "sha256-h6XWZ1lIY7Fl34io1mVpclopTyMmnO/5fLd2FO8Cr+Y=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "fd8bfa0b61ac80181e8e39abde9004e75dc7045e",
+        "rev": "c33c7ace33728f4780b22772ff57a984dee4c800",
         "type": "github"
       },
       "original": {

--- a/lib/common/edna/server.nix
+++ b/lib/common/edna/server.nix
@@ -3,10 +3,13 @@
     inherit (builtins) toJSON;
     inherit (pkgs) writeText;
 
+    vs = config.vault-secrets.secrets;
     profile = "/nix/var/nix/profiles/per-user/deploy/edna-docker";
   in
   {
     networking.firewall.allowedTCPPorts = [ 80 443 ];
+
+    vault-secrets.secrets.docker-backend = {};
 
     virtualisation.docker = {
       enable = true;
@@ -41,6 +44,8 @@
         image = "ghcr.io/serokell/edna-backend";
         imageFile = "${profile}/backend.tar.gz";
         dependsOn = [ "postgres" ];
+
+        environmentFile = "${vs.docker-backend}/environment";
 
         cmd = [
           "-c" "/config.yaml"


### PR DESCRIPTION
Requires https://github.com/serokell/nixpkgs/pull/49. CI will fail until merged and repinned.

Fetch secret environment variables from Vault for backend container.