### PR TITLE
[OPS-1116] Add wasat instance for VPN

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,6 +436,7 @@
         "hermetic": "hermetic",
         "nixpkgs": "nixpkgs_3",
         "serokell-nix": "serokell-nix",
+        "stevenblack-hosts": "stevenblack-hosts",
         "vault-secrets": "vault-secrets"
       }
     },
@@ -458,6 +459,23 @@
       "original": {
         "owner": "serokell",
         "repo": "serokell.nix",
+        "type": "github"
+      }
+    },
+    "stevenblack-hosts": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1620330688,
+        "narHash": "sha256-luRdAUWJvZwyN0acYIDeN5NXruH0/FI358tf5l6NggQ=",
+        "owner": "StevenBlack",
+        "repo": "hosts",
+        "rev": "b933b7dc3f6a4cf647a943a29b1a01779b604ebc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "StevenBlack",
+        "ref": "3.7.1",
+        "repo": "hosts",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
     flake-utils.url = "github:numtide/flake-utils";
     vault-secrets.url = "github:serokell/vault-secrets";
     hermetic.url = "github:serokell/hermetic";
+    stevenblack-hosts = {
+      url = "github:StevenBlack/hosts/3.7.1";
+      flake = false;
+    };
   };
 
   outputs = { self, nixpkgs, serokell-nix, deploy-rs, flake-utils, vault-secrets
@@ -32,7 +36,7 @@
           };
         };
 
-      terraformFor = pkgs: pkgs.terraform.withPlugins (p: with p; [ aws ]);
+      terraformFor = pkgs: pkgs.terraform.withPlugins (p: with p; [ aws vault hcloud ]);
     in {
       nixosConfigurations = mapAttrs (const mkSystem) servers;
 

--- a/servers/wasat/default.nix
+++ b/servers/wasat/default.nix
@@ -62,7 +62,7 @@ in {
   # dns server blocking malicious hostnames
   services.dnsmasq = {
     enable = true;
-    servers = [ "1.1.1.1" ];
+    servers = [ "1.1.1.1" "1.0.0.1" ];
     resolveLocalQueries = false;
     extraConfig = ''
       interface=wg-serokell

--- a/servers/wasat/default.nix
+++ b/servers/wasat/default.nix
@@ -1,0 +1,77 @@
+{ modulesPath, inputs, config, lib, pkgs, ... }:
+
+let
+  vs = config.vault-secrets.secrets;
+
+  wg-keys = import ./wg-keys.nix;
+
+  # hosts from https://github.com/StevenBlack/hosts
+  addn-hosts = pkgs.runCommand "hosts" {} ''
+    # Filter for only comments and redirections to 0.0.0.0, so we can be sure
+    # nothing funky is going on.
+    grep '^#\|^0\.0\.0\.0 ' < ${inputs.stevenblack-hosts}/hosts > $out
+  '';
+
+  # forward port 53 on eth0 to wireguard, for networks that block non-standard ports
+  iptables-rule = "-t nat -A PREROUTING -i eth0 -p udp --dport 53 -j REDIRECT --to-port 35944";
+
+in {
+  imports = [
+    inputs.serokell-nix.nixosModules.hetzner-cloud
+  ];
+
+  networking.hostName = "wasat";
+  wireguard-ip-address = "172.21.0.28";
+
+  hetzner.ipv6Address = "TBD";
+
+  # ensure ethernet interface name is eth0
+  networking.usePredictableInterfaceNames = false;
+
+  networking.firewall.allowedUDPPorts = [
+    53     # wireguard on eth0, dnsmasq on wg-serokell
+    35944  # wireguard
+  ];
+
+  networking.firewall.extraCommands = "ip46tables -A ${iptables-rule}";
+  networking.firewall.extraStopCommands = "ip46tables -D ${iptables-rule}";
+
+  networking.nat = {
+    enable = true;
+    enableIPv6 = true;
+    externalInterface = "eth0";
+    internalInterfaces = [ "wg-serokell" ];
+  };
+
+  # contains wireguard private key
+  vault-secrets.secrets.wireguard-wg-serokell = {};
+
+  networking.wireguard.interfaces.wg-serokell = {
+    listenPort = 35944;
+    ips = [ "172.20.0.0/16" "fd73:7272:ed50::/48" ];
+    privateKeyFile = "${vs.wireguard-wg-serokell}/private_key";
+    peers = lib.flip lib.mapAttrsToList wg-keys (ipSuffix: publicKey: {
+      allowedIPs = [
+        "172.20.0.${ipSuffix}/32"
+        "fd73:7272:ed50::${ipSuffix}/128"
+      ];
+      publicKey = publicKey;
+    });
+  };
+
+  # dns server blocking malicious hostnames
+  services.dnsmasq = {
+    enable = true;
+    servers = [ "1.1.1.1" ];
+    resolveLocalQueries = false;
+    extraConfig = ''
+      interface=wg-serokell
+      bind-interfaces
+      cache-size=4096
+      addn-hosts=${addn-hosts}
+    '';
+  };
+
+  # dnsmasq needs wireguard interface
+  systemd.services.dnsmasq.after = [ "wireguard-wg-serokell.service" ];
+}

--- a/servers/wasat/wg-keys.nix
+++ b/servers/wasat/wg-keys.nix
@@ -1,0 +1,55 @@
+{
+  # (offboarded) "2" = "VxD6G/MJhuFGiJXL5ad5b8SSbC/kgzfQJjIvWFr6th4=";  # Yegor Timoshenko
+  "3"  = "yXXfdeMOAy2qNjZX5jumaAi2qGSb/YEqdqI+HYWO/ho="; # Maxim Koltsov
+  "4"  = "Wi1CW3vJIvxYvdrbBh6TYGdNnDbu6AvhFXxpVoVGEUQ="; # Arseniy Seroka (phone)
+  "5"  = "h/trC+5Z8qbGBJtroYITQGMNUn5XQZ/JRqVR3iIH5Ro="; # Rinat Stryungis (Windows - lenovo)
+  #6   removed
+  # (offboarded - HR-96) "7"  = "yn1o899Ib3PFJZph50YdK6N4Kiyl2vdL1coBLff1mhY="; # Lars Jellema
+  "8"  = "iebbc7JjKvxeNNyRi++Z6F8MRfQMD8NOg0xttUFj40U="; # Yorick van Pelt
+  "9"  = "h/trC+5Z8qbGBJtroYITQGMNUn5XQZ/JRqVR3iIH5Ro="; # Kyrill Briantsev
+  # (offboarded) "10" = "cMc80F788JOdvWlPsQPnT1v9OJrECwTqqnmAPKVthAU="; # Allan Lukwago
+  "11" = "9XA2K8ZAX+Ickgt76WiPr42IsMUkb1e5oyXBrhw/QQU="; # Arseniy Seroka (Mac)
+  "12" = "4YJwhKgnXX/v+Fom9fOH4N/vbt46RBI0V2aZVowZtws="; # Arseniy Seroka (Mac 2)
+  #13  removed
+  "14" = "4KR6fzY0X1JxZtI3CsFyZ+gKHKRM27TGlILk1LBLzUM="; # Kostya Ivanov
+  "15" = "PWlDm/5alF9yjC7/xLCY+FQo0KhpLqV4kdgWoAgvN28="; # Ilya Lubimov
+  "16" = "zHP2fnjWU7DlGjqPvXxJZgoUpJI/bsKSkb7xZAfanC8="; # Ivan Gromakovskii 1 (desktop computer)
+  "17" = "wNLlDMF7HwTlRqOZzyjJCGrXNbrtIdjnYeOukTkOvRE="; # Ivan Gromakovskii 2 (mac)
+  # (offboarded - HR-96) "18" = "2BYngjq0XIP6M2L1CItSFHg44s1UFohECVHOKloYOTI="; # Lars Jellema (phone)
+  "19" = "MdPb8n+oo9/JjYTg1QodjILQGhlxBvRpPfN5Oui/GFQ="; # jupiter.serokell.io
+  "20" = "b56RX/RoeU5Cq4mQTym5JTnI5jvLZ2tnzvC7WO+Lekc="; # Ivan Gromakovskii 3 (phone)
+  "21" = "ZkM+PzUSglJ5QLUXLLslLKj2ew/zGQbLzRrRXS6briQ="; # Dmitrii Mukhutdinov 1 (thinkpad)
+  "22" = "BqqEzv8Whwn+3zM26gRj2Gf7dgTp/DkxFYfRqPoNZVs="; # Dmitrii Mukhutdinov 2 (macos)
+  "23" = "7Y+6DAQh0uQmkxbfASNe/Tz5qoq1FNBY/0lSAPPQTFg="; # Dmitrii Mukhutdinov 3 (ios)
+  # (offboarded) "24" = "Z2ktaCa9MySgC1hUlSg44Jx7iH/MWUC+1Ref2hJGC24="; # Konstantin Andriotis (ios)
+  "26" = "zXvj+Ui21bkyejHbPlUA6VFqpI2uhhYVyQliC3bE6w8="; # Vladislav Zavialov (Mac)
+  # (offboarded) "27" = "57Df3FY2MQKQ0sMS/67r1L9k0gBhOQ4wqCJxRpuWNkE="; # Vasiliy Kevroletin 1 (linux laptop)
+  # (offboarded) "28" = "PUkgnTQq8beemhxIb/ZaPHD8I3qnpP28W5kxVqmoQSw="; # Vasiliy Kevroletin 2 (android phone)
+  # (offboarded) "29" = "cY5XDjkv2UPxIds4RGEgiL0ZNTTx0u5h/097J6WEqzA="; # Dmitry Nikulin 1 (natrium)
+  "30" = "3roYdsqD1wE+GnvBxr5QD1rndIzBb/CkHlzYvnEhQHc="; # Alexander Rukin (Mac)
+  "31" = "34VXmEINtXapvYddPjg3rke8M0Uo7gSa6IGnFSXYNQQ="; # Alexander Rukin (iOS)
+  # (offboarded) "32" = "1ECZItddDjDIaU2gQQl/hFvZIn65/i8t1SQqaRpl70E="; # Artem Ohanjanyan 1 (laptop)
+  "33" = "oIV+kGmyAfDpXTjE8ubJ0Ww/pA2tvLmgLxOriUAUOxs="; # Chris Höppner
+  "34" = "srEmFWWYhzhjWXtZ0ewU0cTyW329jizzT7ElDzBCqkg="; # Jonn Mostovoy (laboratory in latvia)
+  # (offboarded - HR-88) "35" = "5KaouRvlfh45mG64iPXWw9uut4JemAtayJ9lotjEbQo="; # Damir Garifullin
+  "36" = "mhsybC2wiwIlRIDIJYqZEE5aIR8S7fkNxIPIubcVtSU="; # office SPb (srkrt)
+  "37" = "NwZ6bfanB8RxPzsiPvCRId6N8JJLiyXTl6ZB/bfI80I="; # Ilya Peresadin (MacOS)
+  # (offboarded) "38" = "SSayDwgxJv6LFiMw72iPdKLT5PHTrRwx1ODk8Db9wxE="; # Paul Tsupikoff (phone)
+  "39" = "2E/S/T+n53bbP0CV04uayrs6POZ9qZLrtl4Am26naVI="; # Rinat Stryungis (nixOS)
+  "40" = "oIZ4XLs9E/W8UzrTs+byJRBbgs5/HWQtNvP+et27o0w="; # Zhenya Vinogradov
+  # (suspicious traffic) "41" = "uUZiefGUqrMWIFYhAd0oJRVCj3wQEoiYhEVr7ACXYSw="; # Anton Myasnikov (linux)
+  "42" = "6wXyIaig7Syeaj9+fW3J9IxRAYm1WxJKzuA9wEdwGGc="; # Roman Melnikov
+  "43" = "cFleIhfMaB5X+xqxNYrOXgRLqortiVgGzxVo4zkDwEY="; # Kirill Kuvshinov
+  "44" = "ecK/Hr5OhCuGwPDGnNeSFdaPJPAGOJ3gfyK3jeFazSY="; # Grigory Pevnev
+  "45" = "e9HScVFEIG2HchvirXXDLg+wHjvcbxx9rp5Q/f8LewU="; # Aleksandr Pakulev
+  "46" = "gOzFvhKvJQ1l1ukazaEtBxGlv9oD98HExDHzdAMdn3Q="; # Ivan Gromakovskii (lenovo laptop)
+  "47" = "YPi4GCRxt1qAQnb4uqYySTju9uDhxzZnTqme07lvfHs="; # Ilya Lubimov (win)
+  "48" = "NOSFd1t60ZF0ZTty2iq8IfNydKD1yfq5rP5SDaYGlCE="; # Diogo Castro
+  "49" = "OaSGqg6lMyX+7gXxl3vPVwgAMsInupcP39UODGa7tkE="; # Alexander Vereshchagin
+  "50" = "X5ODBmbcLENAnqiXGVSel5IgSIHxL3nq3PRnYTBhgz4="; # Pasquale Pinto
+  "51" = "eZldxihhLW8bIhUt2GCAQSAMXU3PYO7Az4w8rKg0TBE="; # Jonn Mostovoy (work laptop)
+  "52" = "KSK3+6TuGRyf9xe49C5+q2VhWYhWBbsm+B8UMDxFg3Y="; # Alexander Bantyev @balsoft
+  "53" = "wPKA+1WYVAF6QhlLSJAZsk49I0YkoljGaQyA/AgWsjo="; # Alexey Khachiyants (Mac)
+  "54" = "noNARSZ3ARTol2/UT4fq5UlM5FR8dtcxSuq7E/zWWSA="; # Dmitri Puzyrev (ubuntu)
+  "55" = "H8qNx/yIzFmMDVnkJMqoM5OB2+77i0xJ8XK/boFuSDw="; # Andrey Demidenko (tarvos)
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,10 @@ data "aws_route53_zone" "serokell_io" {
   name = "serokell.io"
 }
 
+data "aws_route53_zone" "serokell_net" {
+  name = "serokell.net"
+}
+
 # Grab the latest NixOS AMI built by Serokell
 data "aws_ami" "nixos" {
   most_recent = true
@@ -42,6 +46,11 @@ data "aws_ami" "nixos" {
 resource "aws_key_pair" "balsoft" {
   key_name = "balsoft"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd2OdcSHUsgezuV+cpFqk9+Svtup6PxIolv1zokVZdqvS8qxLsA/rwYmQgTnuq4/zK/GIxcUCH4OxYlW6Or4M4G7qrDKcLAUrRPWkectqEooWRflZXkfHduMJhzeOAsBdMfYZQ9024GwKr/4yriw2BGa8GbbAnQxiSeTipzvXHoXuRME+/2GsMFAfHFvxzXRG7dNOiLtLaXEjUPUTcw/fffKy55kHtWxMkEvvcdyR53/24fmO3kLVpEuoI+Mp1XFtX3DvRM9ulgfwZUn8/CLhwSLwWX4Xf9iuzVi5vJOJtMOktQj/MwGk4tY/NPe+sIk+nAUKSdVf0y9k9JrJT98S/ cardno:000610645773"
+}
+
+resource "hcloud_ssh_key" "zhenya" {
+  name = "zhenya"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDVESCckOB+2NoojRR+rMl2N4OTf7PQR2BvcxF7cMeRtpSDnMQwbitJNCm0tNygUa8Sn5obaS0HSTfvefIPaDOhgDwi/hGznHiCI3+cAesi/GXXq5p+ota/Ab2oQOFsAquy3sGxNaMhVwU2FU8uyDmiCEbS8kKWAW/YXVqRTPsbkkNBJIwetvzXyrFrYZeCdShZmcPtOGHLpUByKhXkQHXpZ86Bbu9NH/0GsFamADlRaoQQa1+oTWPCWvwsctsAUcHw4/jpeHQffCFATYYS57xYXKkjMZJHypDyjJB9U40bX/HZYaTMP4fDlXeEO/OU2YkAJdt0NBylcE1WzFrOKRNBCcgfgHBzsD3rxMvVNPAl/JXTiEBpXZoza8p+gmQRMMe9SDQLz9pRN7paRsAi1qaQnFV1DbCBPrY2OezJujIuRKc8t0D3nEgg5rcYi2fcFkJscwAsvspTBnK9LCC5ojqa0O5BGTYwlxp2cUkFbWyM2oaRqcQo3ypPaJBybo/TF2FqqHlWNlckwOPPTGngThT6kkFEF+kqMUlUdokiWcpl2K7psfl5RdYGIFfey74NiqoSZ9gyta2WBkY7J41YrsQh20vtGhWWYl/+pDo3cggqmP0fEmD5CaPZXimvHjOjfcxGMooPpkOl3G3I0eQSpvlPpLZHEhh5fThFIAF2RxN/IQ== zhenyavinogradov@gmail.com"
 }
 
 # Allow ALL egress traffic

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,3 +2,17 @@ provider  "aws" {
   version = "= 3.27"
   region = "eu-west-2"
 }
+
+provider "vault" {
+  address = "https://vault.serokell.org:8200/"
+  version = "~> 2.11"
+}
+
+data "vault_generic_secret" "hcloud_token" {
+  path = "kv/sys/hetzner/tokens/gemini"
+}
+
+provider "hcloud" {
+  version = "~> 1.22"
+  token   = data.vault_generic_secret.hcloud_token.data["token"]
+}

--- a/terraform/wasat.tf
+++ b/terraform/wasat.tf
@@ -1,0 +1,47 @@
+resource "hcloud_server" "wasat" {
+  name        = "wasat"
+  image       = "ubuntu-20.04"
+  server_type = "cx11"
+  ssh_keys    = [hcloud_ssh_key.zhenya.id]
+  # Install NixOS 20.09
+  user_data = <<EOF
+    #cloud-config
+
+    runcmd:
+      - curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | NIX_CHANNEL=nixos-20.09 bash 2>&1 | tee /tmp/infect.log
+EOF
+}
+
+resource "aws_route53_record" "wasat_gemini_serokell_team_ipv4" {
+  zone_id = aws_route53_zone.gemini_serokell_team.zone_id
+  name    = "wasat.${aws_route53_zone.gemini_serokell_team.name}"
+  type    = "A"
+  ttl     = "60"
+  records = [hcloud_server.wasat.ipv4_address]
+}
+
+resource "aws_route53_record" "wasat_gemini_serokell_team_ipv6" {
+  zone_id = aws_route53_zone.gemini_serokell_team.zone_id
+  name    = "wasat.${aws_route53_zone.gemini_serokell_team.name}"
+  type    = "AAAA"
+  ttl     = "60"
+  records = [hcloud_server.wasat.ipv6_address]
+}
+
+# serokell.net DNS records (can't be a CNAME becase it's a zone apex)
+# (switch later)
+# resource "aws_route53_record" "serokell_net_ipv4" {
+#   zone_id = data.aws_route53_zone.serokell_net.zone_id
+#   name    = "serokell.net"
+#   type    = "A"
+#   ttl     = "60"
+#   records = [hcloud_server.wasat.ipv4_address]
+# }
+
+# resource "aws_route53_record" "serokell_net_ipv6" {
+#   zone_id = data.aws_route53_zone.serokell_net.zone_id
+#   name    = "serokell.net"
+#   type    = "AAAA"
+#   ttl     = "60"
+#   records = [hcloud_server.wasat.ipv6_address]
+# }


### PR DESCRIPTION
Moves wireguard VPN configuration from pluto. Pluto also had nginx server, but I think nobody is using it, so I dropped it. The server is hosted in hetzner cloud because traffic is cheaper than in AWS there.

