### PR TITLE
Update serokell.nix and add diogo to users on alzirr

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1621844655,
-        "narHash": "sha256-LlXyUc7tNNmnWS/W0zz0OVtpSgEu1zBxp0TBPxNokdg=",
+        "lastModified": 1629443741,
+        "narHash": "sha256-7bZGo9qXYxYD2FMZWlWoQbp3/NNG1YSHLEjEOHI4YRM=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "42b192ca488df6e0ae5f4e3abbe99e615b632e55",
+        "rev": "46d762e5107d10ad409295a7f668939c21cc048d",
         "type": "github"
       },
       "original": {

--- a/servers/alzirr/deployment.nix
+++ b/servers/alzirr/deployment.nix
@@ -13,7 +13,7 @@ in
 
   serokell-users = {
     wheelUsers = [ "sweater" ];
-    regularUsers = [ "slowpnir" ];
+    regularUsers = [ "slowpnir" "diogo" ];
   };
 
   environment.systemPackages = with pkgs; [
@@ -80,6 +80,7 @@ in
   services.nginx = {
     enable = true;
     openFirewall = true;
+    addSecurityHeaders = false;
     virtualHosts = {
       swampwalk = {
         forceSSL = true;


### PR DESCRIPTION
This also includes utilizing `addSecurityHeaders = false;` on Alzirr as introduced in https://github.com/serokell/serokell.nix/pull/46 to fix evaluation with a newer serokell.nix version.