### PR TITLE
[OPS-1269] Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .envrc
 .terraform/
+.terraform.lock.hcl
 result*
 .tmp
 terraform.tfstate*

--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1603796912,
-        "narHash": "sha256-6ayqpH/4XiEXylNdWI3AghubqS6XuiPg3Y60jY8RTo4=",
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "19576c2aea7f074ff0da818b21a8b0950ff6ec86",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1605370193,
-        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
     "gitignore-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1594969032,
-        "narHash": "sha256-nbZfz02QoVe1yYK7EtCV7wMi4VdHzZEoPg20ZSDo9to=",
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "c4662e662462e7bf3c2a968483478a665d00e717",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
         "type": "github"
       },
       "original": {
@@ -301,6 +301,7 @@
       "original": {
         "owner": "nixos",
         "repo": "nix",
+        "rev": "79aa7d95183cbe6c0d786965f0dbff414fd1aa67",
         "type": "github"
       }
     },
@@ -385,11 +386,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1617871354,
-        "narHash": "sha256-3sCuJbCke12dnvude2nxk2isrGPdvZT3uM9A/fcb1Hs=",
+        "lastModified": 1631273642,
+        "narHash": "sha256-LeD8U6LijyPHgr5ECLk7cobb4EkgPyPJJjxcYNi8noo=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "fd8bfa0b61ac80181e8e39abde9004e75dc7045e",
+        "rev": "1714a2ead1a18678afa3cbf75dff3f024c579061",
         "type": "github"
       },
       "original": {
@@ -449,11 +450,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1629443741,
-        "narHash": "sha256-7bZGo9qXYxYD2FMZWlWoQbp3/NNG1YSHLEjEOHI4YRM=",
+        "lastModified": 1631698234,
+        "narHash": "sha256-cHEODbTcJTuhYfNadxapIjRi/eta2AufzOg9oNVS+YY=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "46d762e5107d10ad409295a7f668939c21cc048d",
+        "rev": "560b4d1583857ff1e5ce5e63461268ae74fd6260",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1621509262,
-        "narHash": "sha256-XyCLtTVTQPXM5LXA1vffP27/tWwEn9VVESESHYNNMFA=",
+        "lastModified": 1628752686,
+        "narHash": "sha256-Lzh9MYUJDsjgif+YEyOErXtj1IH+ci8J1C30g1ms69s=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "d2d05e1357b84d5d70a3acba866c01eca2e4e2aa",
+        "rev": "e5546f9c2503c26d175f08a81fc0a0f330be4cbe",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1606424373,
-        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1610392286,
-        "narHash": "sha256-3wFl5y+4YZO4SgRYK8WE7JIS3p0sxbgrGaQ6RMw+d98=",
+        "lastModified": 1622810282,
+        "narHash": "sha256-4wmvM3/xfD0hCdNDIXVzRMfL4yB1J+DjH6Zte2xbAxk=",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "d7bfbad3304fd768c0f93a4c3b50976275e6d4be",
+        "rev": "e8061169e1495871b56be97c5c51d310fae01374",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1610942247,
-        "narHash": "sha256-PKo1ATAlC6BmfYSRmX0TVmNoFbrec+A5OKcabGEu2yU=",
+        "lastModified": 1622972307,
+        "narHash": "sha256-ENOu0FPCf95iLLoq2txhJtnA2ZpOFhIVBqQVbKM8ra0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7d71001b796340b219d1bfa8552c81995017544a",
+        "rev": "d8eb97e3801bde96491535f40483d550b57605b9",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1620677945,
-        "narHash": "sha256-h6XWZ1lIY7Fl34io1mVpclopTyMmnO/5fLd2FO8Cr+Y=",
+        "lastModified": 1631273642,
+        "narHash": "sha256-LeD8U6LijyPHgr5ECLk7cobb4EkgPyPJJjxcYNi8noo=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "c33c7ace33728f4780b22772ff57a984dee4c800",
+        "rev": "1714a2ead1a18678afa3cbf75dff3f024c579061",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1610051610,
-        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "lastModified": 1622445595,
+        "narHash": "sha256-m+JRe6Wc5OZ/mKw2bB3+Tl0ZbtyxxxfnAWln8Q5qs+Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "rev": "7d706970d94bc5559077eb1a6600afddcd25a7c8",
         "type": "github"
       },
       "original": {
@@ -502,11 +502,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1620684327,
-        "narHash": "sha256-CMxd5qYGE6k3nawLbZNJco0YOyvTQGthA8uRQop+iX0=",
+        "lastModified": 1625677793,
+        "narHash": "sha256-m6usFrtq+8xt4gGSWSEaYXVU97skyoaUKBY57eomZbw=",
         "owner": "serokell",
         "repo": "vault-secrets",
-        "rev": "870b781df11687844e87ba8590fb41870d03a830",
+        "rev": "4b2d76cedd84873778d0c7bbfa0116e1fb9bd2c1",
         "type": "github"
       },
       "original": {

--- a/lib/common/edna/server.nix
+++ b/lib/common/edna/server.nix
@@ -45,7 +45,7 @@
         imageFile = "${profile}/backend.tar.gz";
         dependsOn = [ "postgres" ];
 
-        environmentFile = "${vs.docker-backend}/environment";
+        environmentFiles = [ "${vs.docker-backend}/environment" ];
 
         cmd = [
           "-c" "/config.yaml"

--- a/servers/alzirr/deployment.nix
+++ b/servers/alzirr/deployment.nix
@@ -59,6 +59,7 @@ in
   };
 
   users.users.deploy = {
+    isSystemUser = true;
     useDefaultShell = true;
 
     openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1MvqWKMAejgaBfm0mXqwRK7QZ6NNOzCGj9aX+tiiow" ];

--- a/servers/castor/default.nix
+++ b/servers/castor/default.nix
@@ -13,6 +13,7 @@
 
   # Deployment user
   users.users.deploy = {
+    isSystemUser = true;
     useDefaultShell = true;
     openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOA+/SMYgdibz1vkEKl2Hyi5epcZ91Q+vjWUoLiATj4R edna" ];
   };

--- a/servers/jishui/default.nix
+++ b/servers/jishui/default.nix
@@ -13,6 +13,7 @@
 
   # Deployment user
   users.users.deploy = {
+    isSystemUser = true;
     useDefaultShell = true;
     openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOA+/SMYgdibz1vkEKl2Hyi5epcZ91Q+vjWUoLiATj4R edna" ];
   };

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,8 +6,24 @@ terraform {
     key    = "gemini/terraform.tfstate"
     region = "eu-west-2"
   }
+
   ## Prevent unwanted updates
-  required_version = "= 0.12.30" # Use nix-shell or nix develop
+  required_version = "1.0.4" # Use nix-shell or nix develop
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.43.0"
+    }
+    hcloud = {
+      source = "nixpkgs/hcloud"
+      version = "~> 1.26.0"
+    }
+    vault = {
+      source = "hashicorp/vault"
+      version = "~> 2.11.0"
+    }
+  }
 }
 
 resource "aws_route53_zone" "gemini_serokell_team" {
@@ -147,7 +163,6 @@ resource "aws_security_group" "wireguard" {
 # Network resources
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
-  version = "= v2.46.0"
 
   name = "gemini-vpc"
   cidr = "10.0.0.0/16"

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,11 +1,9 @@
 provider  "aws" {
-  version = "= 3.27"
   region = "eu-west-2"
 }
 
 provider "vault" {
   address = "https://vault.serokell.org:8200/"
-  version = "~> 2.11"
 }
 
 data "vault_generic_secret" "hcloud_token" {
@@ -13,6 +11,5 @@ data "vault_generic_secret" "hcloud_token" {
 }
 
 provider "hcloud" {
-  version = "~> 1.22"
   token   = data.vault_generic_secret.hcloud_token.data["token"]
 }


### PR DESCRIPTION
Update nix dependencies.

Related issue: https://issues.serokell.io/issue/OPS-1269