### PR TITLE
Pin Terraform VPC module using Nix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,3 @@ steps:
   - label: Check Nix flake
     commands:
       - nix-shell --run 'nix flake check -L'
-  - label: Check Terraform
-    commands:
-      - nix-shell --run 'cd terraform && terraform init -backend=false && terraform validate'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .envrc
 .terraform/
+.terraform_nix/
 .terraform.lock.hcl
 result*
 .tmp

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
           mkdir -p $PWD/terraform/.terraform_nix/modules/
           rm -rf $PWD/terraform/.terraform_nix/modules/vpc
           ln -s ${vpcModule} $PWD/terraform/.terraform_nix/modules/vpc
-          ${terraform}/bin/terraform $@
+          ${terraform}/bin/terraform "$@"
         '';
       in {
 
@@ -85,8 +85,6 @@
         devShell = pkgs.mkShell {
           VAULT_ADDR = "https://vault.serokell.org:8200";
           SSH_OPTS = "${builtins.concatStringsSep " " self.deploy.sshOpts}";
-          shellHook = ''
-          '';
           buildInputs = [
             deploy-rs.packages.${system}.deploy-rs
             pkgs.vault

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -185,7 +185,7 @@ resource "aws_security_group" "wireguard" {
 
 # Network resources
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source = "./.terraform_nix/modules/vpc"
 
   name = "gemini-vpc"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
This is a bit ugly but the best solution I can think of right now, this pins our VPC module using Nix so we are able to use the Nix flake check for Terraform, and removes the need to manually downgrade the VPC module version when initializing terraform.