### PR TITLE
flake.nix: fix shell nix version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
             (pkgs.vault-push-approle-envs self)
             (pkgs.vault-push-approles self)
             terraform-pinned
-            pkgs.nixUnstable
+            pkgs.nix
             pkgs.aws
           ];
         };


### PR DESCRIPTION
since we've re-pinned nixpkgs, we can use stable nix for building