### PR TITLE
Switch to mkPipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,0 @@
-steps:
-  - label: Check Nix flake
-    commands:
-      - nix-shell --run 'nix flake check -L'


### PR DESCRIPTION
Switch from just running `nix flake check` to using `mkPipeline`, and mimic some arbitrary changes made to this config when copying most of it to tezos-infra (where `mkPipeline` is now also used)