### PR TITLE
tejat-prior: backup murmur state to restic w' b2

### DIFF
--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -10,6 +10,13 @@ with lib;
       allowedUDPPorts = [ config.services.murmur.port ];
     };
 
+  vault-secrets.secrets.backups = { user = "restic"; };
+  services.restic.backups.murmur = {
+    environmentFile = "${config.vault-secrets.secrets.backups}/environment";
+    repository = "b2:srk-bkp:test-murmur";
+    initialize = true;
+    paths = [ "/var/lib/murmur" ];
+  };
 
   containers.ligo-webide-thing = {
     autoStart = true;


### PR DESCRIPTION
Currently there are problems with inability to share backup credentials between several machines, due to approle thing restricting secret access too tight