### PR TITLE
[LIGO-764] update webide and rework it to profile-based approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,16 @@ All necessary programs and dependencies are provided by Nix in `nix-shell` or `n
 
 ## Servers
 
-| Name      | Function         | IP            |
-| :-------: | :--------------: | :-----------: |
-| Alhena    | Hermetic         |               |
-| Alzirr    | Swampwalk/TT     | 135.181.78.88 |
-| Castor    | EDNA Staging     |               |
-| Jishui    | EDNA Demo        |               |
-| Mekbuda   | MTProxy server   |               |
+| Name        | Function              | IP            |
+| :---------: | :-------------------: | :-----------: |
+| Alhena      | Hermetic              |               |
+| Alzirr      | Swampwalk/TT          | 135.181.78.88 |
+| Castor      | EDNA Staging          |               |
+| Jishui      | EDNA Demo             |               |
+| Mebsuta     | vpn.serokell.net      |               |
+| Mekbuda     | MTProxy server        |               |
+| Tejat Prior | Mumble + Ligo Web IDE |               |
+| Wasat       | Old Wireguard server  |               |
 
 <!-- Don't forget to add the servers on https://www.notion.so/serokell/Server-Naming-Scheme-c189819000164fb090377c75e4ce7da6 -->
 

--- a/flake.lock
+++ b/flake.lock
@@ -120,8 +120,27 @@
     "deploy-rs_2": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_3",
         "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1659725433,
+        "narHash": "sha256-1ZxuK67TL29YLw88vQ18Y2Y6iYg8Jb7I6/HVzmNB6nM=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "41f15759dd8b638e7b4f299730d94d5aa46ab7eb",
+        "type": "github"
+      },
+      "original": {
+        "id": "deploy-rs",
+        "type": "indirect"
+      }
+    },
+    "deploy-rs_3": {
+      "inputs": {
+        "flake-compat": "flake-compat_8",
+        "nixpkgs": "nixpkgs_15",
+        "utils": "utils_3"
       },
       "locked": {
         "lastModified": 1648475189,
@@ -150,6 +169,21 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "type": "github"
+      }
+    },
+    "flake-compat_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-compat",
+        "type": "indirect"
       }
     },
     "flake-compat_2": {
@@ -202,11 +236,11 @@
     "flake-compat_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -215,6 +249,54 @@
       }
     },
     "flake-compat_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_9": {
       "flake": false,
       "locked": {
         "lastModified": 1627913399,
@@ -243,6 +325,20 @@
         "type": "indirect"
       }
     },
+    "flake-utils_10": {
+      "locked": {
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
     "flake-utils_2": {
       "locked": {
         "lastModified": 1601282935,
@@ -260,35 +356,20 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "id": "flake-utils",
+        "type": "indirect"
       }
     },
     "flake-utils_4": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
-    "flake-utils_5": {
-      "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
@@ -302,7 +383,51 @@
         "type": "github"
       }
     },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
     "flake-utils_6": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_8": {
       "locked": {
         "lastModified": 1631561581,
         "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
@@ -314,6 +439,21 @@
       "original": {
         "id": "flake-utils",
         "type": "indirect"
+      }
+    },
+    "flake-utils_9": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "ghc-8.6.5-iohk": {
@@ -365,14 +505,30 @@
         "type": "github"
       }
     },
+    "gitignore-nix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1655774123,
-        "narHash": "sha256-EEPkjdTo1+fN5D0k5S+UxJagg8xXXuDLSPYKPc57MCA=",
+        "lastModified": 1662426839,
+        "narHash": "sha256-SeWoMXTPsEdAMmYb5zqynM83mKV9DcXOPKTWU7fafeo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4bc066f2105d4255d65599c3d0fce2e673aa4d45",
+        "rev": "a75e8d07d46728d80911bd10edd3f23a9754af10",
         "type": "github"
       },
       "original": {
@@ -388,7 +544,7 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
@@ -402,22 +558,22 @@
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1655782721,
-        "narHash": "sha256-g19G7fXx2HR6+Oou3esHPwzNteqNRmOrjNNCBwez8F8=",
+        "lastModified": 1662426997,
+        "narHash": "sha256-TlNUlQeXDofi8f3FjIYwdXgyOgHvUOzJvNAe/mAHFNY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1eaa396e9c6a74dc0e0c7a01c4f0b477c66503f3",
+        "rev": "a374b4b2acb637ebff951b2853abe57bb738714b",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "type": "github"
+        "id": "haskell-nix",
+        "type": "indirect"
       }
     },
     "hermetic": {
@@ -482,35 +638,22 @@
         "type": "indirect"
       }
     },
-    "ligo": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1655758176,
-        "narHash": "sha256-qkGEaNi3h8BSte2Mw6EmM/tORC9MvLoMU3AuU8kvaxA=",
-        "ref": "refs/heads/tooling",
-        "rev": "74326c5aeaaffaa7abd06e21df18caff363dc26e",
-        "revCount": 9785,
-        "type": "git",
-        "url": "https://gitlab.com/serokell/ligo/ligo"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://gitlab.com/serokell/ligo/ligo"
-      }
-    },
     "ligo-webide": {
       "inputs": {
+        "deploy-rs": "deploy-rs_2",
+        "flake-utils": "flake-utils_3",
         "haskell-nix": "haskell-nix",
-        "ligo": "ligo",
-        "nixpkgs": "nixpkgs_4"
+        "nix-npm-buildpackage": "nix-npm-buildpackage",
+        "nixpkgs": "nixpkgs_6",
+        "tezos-packaging": "tezos-packaging"
       },
       "locked": {
         "dir": "tools/webide-new",
-        "lastModified": 1661241587,
-        "narHash": "sha256-SDV8TQGZ8BuHjJroEcJ/lzPMA0yzOG0ErOOfDO6EZoc=",
+        "lastModified": 1666941156,
+        "narHash": "sha256-402BQesPbe1mqOo58KNLCQesR8dJiDn7RI4i+u9Q2tI=",
         "ref": "refs/heads/tooling",
-        "rev": "0ea983c9edc0e75f5bbbe844a133dd41ca12b622",
-        "revCount": 10375,
+        "rev": "ba9ee6b907f9e6d4b194e26081e44f449b9ee7a5",
+        "revCount": 11542,
         "type": "git",
         "url": "https://gitlab.com/serokell/ligo/ligo?dir=tools%2fwebide-new"
       },
@@ -555,6 +698,38 @@
     "lowdown-src_3": {
       "flake": false,
       "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_5": {
+      "flake": false,
+      "locked": {
         "lastModified": 1632468475,
         "narHash": "sha256-NNOm9CbdA8cuwbvaBHslGbPTiU6bh1Ao+MpEPx4rSGo=",
         "owner": "kristapsdz",
@@ -568,7 +743,7 @@
         "type": "github"
       }
     },
-    "lowdown-src_4": {
+    "lowdown-src_6": {
       "flake": false,
       "locked": {
         "lastModified": 1632468475,
@@ -604,7 +779,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -622,14 +797,32 @@
         "type": "github"
       }
     },
+    "nix-npm-buildpackage": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1664286682,
+        "narHash": "sha256-OBdpqW2zpwYF/JWUk013rbMdIC3R17ynX78tQPbfHNw=",
+        "owner": "serokell",
+        "repo": "nix-npm-buildpackage",
+        "rev": "bc0c4989f664ff262d3ab39cad9dc0f6f1c10017",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "nix-npm-buildpackage",
+        "type": "github"
+      }
+    },
     "nix-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1649424170,
-        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "lastModified": 1659569011,
+        "narHash": "sha256-wHS0H5+TERmDnPCfzH4A+rSR5TvjYMWus9BNeNAMyUM=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "rev": "555d57e1ea81b79945f2608aa261df20f6b602a5",
         "type": "github"
       },
       "original": {
@@ -638,11 +831,51 @@
         "type": "github"
       }
     },
+    "nix-unstable": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_3",
+        "nixpkgs": "nixpkgs_11",
+        "nixpkgs-regression": "nixpkgs-regression_3"
+      },
+      "locked": {
+        "lastModified": 1657815848,
+        "narHash": "sha256-O0zNDRux3Yyplp5MkJ+A+wLzMUWnhbc/l8EnaHskQAI=",
+        "owner": "nixos",
+        "repo": "nix",
+        "rev": "ca4d5bee09df0393dd525b3cd5159a23d4683f2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
+        "lastModified": 1657815848,
+        "narHash": "sha256-O0zNDRux3Yyplp5MkJ+A+wLzMUWnhbc/l8EnaHskQAI=",
+        "owner": "nixos",
+        "repo": "nix",
+        "rev": "ca4d5bee09df0393dd525b3cd5159a23d4683f2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_3": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_4",
+        "nixpkgs": "nixpkgs_13",
+        "nixpkgs-regression": "nixpkgs-regression_4"
       },
       "locked": {
         "lastModified": 1657886512,
@@ -659,10 +892,10 @@
         "type": "github"
       }
     },
-    "nix_3": {
+    "nix_4": {
       "inputs": {
-        "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_8"
+        "lowdown-src": "lowdown-src_5",
+        "nixpkgs": "nixpkgs_16"
       },
       "locked": {
         "lastModified": 1633098935,
@@ -677,10 +910,10 @@
         "type": "indirect"
       }
     },
-    "nix_4": {
+    "nix_5": {
       "inputs": {
-        "lowdown-src": "lowdown-src_4",
-        "nixpkgs": "nixpkgs_10"
+        "lowdown-src": "lowdown-src_6",
+        "nixpkgs": "nixpkgs_18"
       },
       "locked": {
         "lastModified": 1633098935,
@@ -729,11 +962,11 @@
     },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1645296114,
-        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "lastModified": 1655034179,
+        "narHash": "sha256-rf1/7AbzuYDw6+8Xvvf3PtEOygymLBrFsFxvext5ZjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "rev": "046ee4af7a9f016a364f8f78eeaa356ba524ac31",
         "type": "github"
       },
       "original": {
@@ -745,16 +978,32 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1648744337,
-        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "lastModified": 1656782578,
+        "narHash": "sha256-1eMCBEqJplPotTo/SZ/t5HU6Sf2I8qKlZi9MX7jv9fw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "rev": "573603b7fdb9feb0eb8efc16ee18a015c667ab1b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1657876628,
+        "narHash": "sha256-URmf0O2cQ/3heg2DJOeLyU/JmfVMqG4X5t9crQXMaeY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549d82bdd40f760a438c3c3497c1c61160f3de55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -790,7 +1039,148 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression_3": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_4": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1657888067,
+        "narHash": "sha256-GnwJoFBTPfW3+mz7QEeJEEQ9OMHZOiIJ/qDhZxrlKh8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "65fae659e31098ca4ac825a6fef26d890aaf3f4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1657802959,
+        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1640418986,
+        "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1653988320,
+        "narHash": "sha256-ZaqFFsSDipZ6KVqriwM34T739+KLYJvNmCWzErjAg7c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fa57ed190fd6c7c746319444f34b5917666e5c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1655108282,
+        "narHash": "sha256-snIu1rBgc+IwoG+mjvp2Thq9C5L+RYvV/DEdfYVzp2s=",
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "rev": "7887e272ab2ad8376d54ca5f58df0ed7f67676e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
+      "locked": {
+        "lastModified": 1651144877,
+        "narHash": "sha256-GX9VhRym/XDoI78Eqvq9wCPB7li/xqxLEzQpkdhBFbA=",
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "rev": "cf0afe951da00abdcac2dfbf9fcb26ac9ba8c85e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
@@ -806,7 +1196,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_10": {
+    "nixpkgs_16": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -821,7 +1211,36 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_17": {
+      "locked": {
+        "lastModified": 1632495107,
+        "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "rev": "be220b2dc47092c1e739bf6aaf630f29e71fe1c4",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_18": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_19": {
       "locked": {
         "lastModified": 1632495107,
         "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
@@ -851,65 +1270,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1655400192,
-        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1651144877,
-        "narHash": "sha256-GX9VhRym/XDoI78Eqvq9wCPB7li/xqxLEzQpkdhBFbA=",
-        "owner": "serokell",
-        "repo": "nixpkgs",
-        "rev": "cf0afe951da00abdcac2dfbf9fcb26ac9ba8c85e",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
@@ -924,7 +1284,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -939,7 +1299,51 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1653917367,
+        "narHash": "sha256-04MsJC0g9kE01nBuXThMppZK+yvCZECQnUaZKSU+HJo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "437c8e6554911095f0557d524e9d2ffe1c26e33a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1655400192,
+        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1653988320,
+        "narHash": "sha256-ZaqFFsSDipZ6KVqriwM34T739+KLYJvNmCWzErjAg7c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fa57ed190fd6c7c746319444f34b5917666e5c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1632495107,
         "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
@@ -951,6 +1355,22 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1640319671,
+        "narHash": "sha256-ZkKmakwaOaLiZOpIZWbeJZwap5CzJ30s4UJTfydYIYc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "eac07edbd20ed4908b98790ba299250b5527ecdf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "old-ghc-nix": {
@@ -970,6 +1390,66 @@
         "type": "github"
       }
     },
+    "opam-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_6",
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": "nixpkgs_9",
+        "opam-repository": [
+          "ligo-webide",
+          "tezos-packaging",
+          "opam-repository"
+        ],
+        "opam2json": "opam2json"
+      },
+      "locked": {
+        "lastModified": 1657909029,
+        "narHash": "sha256-dsNIoNA4C2hu/5TllM89+7RUqchVjp8CUUSmG69Z2w0=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "ac7ba6e749c01379c748eda43ae715e1a8fa671f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
+    "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1658925975,
+        "narHash": "sha256-08NjrvGhGTYOzR/fQkVq+GnhbzjGFXcNG52Z0LDiY2s=",
+        "owner": "tezos",
+        "repo": "opam-repository",
+        "rev": "d19f422fc819da8d82d2214e1105ca3867f0e1eb",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "tezos",
+        "repo": "opam-repository",
+        "type": "gitlab"
+      }
+    },
+    "opam2json": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_10"
+      },
+      "locked": {
+        "lastModified": 1651529032,
+        "narHash": "sha256-fe8bm/V/4r2iNxgbitT2sXBqDHQ0GBSnSUSBg/1aXoI=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "e8e9f2fa86ef124b9f7b8db41d3d19471c1d8901",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "composition-c4": "composition-c4",
@@ -978,9 +1458,9 @@
         "flake-utils": "flake-utils",
         "hermetic": "hermetic",
         "ligo-webide": "ligo-webide",
-        "nix": "nix_2",
-        "nixpkgs": "nixpkgs_6",
-        "serokell-nix": "serokell-nix",
+        "nix": "nix_3",
+        "nixpkgs": "nixpkgs_14",
+        "serokell-nix": "serokell-nix_2",
         "stevenblack-hosts": "stevenblack-hosts",
         "subspace": "subspace",
         "vault-secrets": "vault-secrets"
@@ -988,12 +1468,33 @@
     },
     "serokell-nix": {
       "inputs": {
-        "deploy-rs": "deploy-rs_2",
-        "flake-compat": "flake-compat_5",
-        "flake-utils": "flake-utils_4",
+        "flake-compat": "flake-compat_7",
+        "flake-utils": "flake-utils_7",
         "gitignore-nix": "gitignore-nix",
-        "nix": "nix_3",
-        "nixpkgs": "nixpkgs_9"
+        "nix-unstable": "nix-unstable",
+        "nixpkgs": "nixpkgs_12"
+      },
+      "locked": {
+        "lastModified": 1629443741,
+        "narHash": "sha256-7bZGo9qXYxYD2FMZWlWoQbp3/NNG1YSHLEjEOHI4YRM=",
+        "owner": "serokell",
+        "repo": "serokell.nix",
+        "rev": "46d762e5107d10ad409295a7f668939c21cc048d",
+        "type": "github"
+      },
+      "original": {
+        "id": "serokell-nix",
+        "type": "indirect"
+      }
+    },
+    "serokell-nix_2": {
+      "inputs": {
+        "deploy-rs": "deploy-rs_3",
+        "flake-compat": "flake-compat_9",
+        "flake-utils": "flake-utils_8",
+        "gitignore-nix": "gitignore-nix_2",
+        "nix": "nix_4",
+        "nixpkgs": "nixpkgs_17"
       },
       "locked": {
         "lastModified": 1663574694,
@@ -1011,11 +1512,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1655687733,
-        "narHash": "sha256-/Ngfyu0IFzCD21xjxXxcKvhPc5qEXEufWuF5oBbe+IU=",
+        "lastModified": 1662426933,
+        "narHash": "sha256-xVDJMgvUQpjhlgIvxxCpBvj0n5nzKOlmN02y/wu303A=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "2e5ca12507b0da588b1f5c5dee83e32d75ea1999",
+        "rev": "2a592aadd459361c38e189a2f1c40da692558089",
         "type": "github"
       },
       "original": {
@@ -1043,7 +1544,7 @@
     },
     "subspace": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1059,6 +1560,48 @@
       "original": {
         "owner": "serokell",
         "repo": "subspace",
+        "type": "github"
+      }
+    },
+    "tezos": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1659347743,
+        "narHash": "sha256-kc0Q+2crcj0P4iWJBpOzD6ww3kDExmujyIUSJj+iEH8=",
+        "owner": "tezos",
+        "repo": "tezos",
+        "rev": "4ca331940db0b62ab98ad14d7c032db292879805",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "tezos",
+        "repo": "tezos",
+        "type": "gitlab"
+      }
+    },
+    "tezos-packaging": {
+      "inputs": {
+        "flake-compat": "flake-compat_5",
+        "flake-utils": "flake-utils_5",
+        "nix": "nix_2",
+        "nixpkgs": "nixpkgs_8",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "opam-nix": "opam-nix",
+        "opam-repository": "opam-repository",
+        "serokell-nix": "serokell-nix",
+        "tezos": "tezos"
+      },
+      "locked": {
+        "lastModified": 1663609730,
+        "narHash": "sha256-PJXEYiuKBA6B/eHupuA+XL/F1ResAjXW2Lb8KcMzkQo=",
+        "owner": "serokell",
+        "repo": "tezos-packaging",
+        "rev": "2e16001bf809f4054331c314ce8e27946ff8355c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "tezos-packaging",
         "type": "github"
       }
     },
@@ -1092,12 +1635,27 @@
         "type": "github"
       }
     },
+    "utils_3": {
+      "locked": {
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "vault-secrets": {
       "inputs": {
-        "flake-compat": "flake-compat_6",
-        "flake-utils": "flake-utils_6",
-        "nix": "nix_4",
-        "nixpkgs": "nixpkgs_11"
+        "flake-compat": "flake-compat_10",
+        "flake-utils": "flake-utils_10",
+        "nix": "nix_5",
+        "nixpkgs": "nixpkgs_19"
       },
       "locked": {
         "lastModified": 1633626134,

--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -17,6 +17,7 @@ with lib;
     isSystemUser = true;
     useDefaultShell = true;
     group = "deploy";
+    openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINBuEKUhfJWZXUqgE2hN+aekbRj5yU8Q0kT4FjducocP webide" ];
   };
 
   security.sudo.extraRules = [

--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -26,6 +26,9 @@ with lib;
     hostAddress = "192.168.100.10";
     localAddress = "192.168.100.11";
   };
+  networking.nat.enable = true;
+  networking.nat.internalInterfaces = ["ve-+"];
+  networking.nat.externalInterface = "ens5";
 
   services.nginx = {
     enable = true;

--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -1,4 +1,7 @@
 { modulesPath, inputs, config, pkgs, lib, ... }:
+let
+  profile-root = "/nix/var/nix/profiles/per-user/deploy";
+in
 with lib;
 {
   imports = [
@@ -10,17 +13,41 @@ with lib;
       allowedUDPPorts = [ config.services.murmur.port ];
     };
 
+  users.users.deploy = {
+    isSystemUser = true;
+    useDefaultShell = true;
+    group = "deploy";
+  };
+
+  security.sudo.extraRules = [
+    {
+      users = [ "deploy" ];
+      commands = [{
+        command = "/run/current-system/sw/bin/systemctl restart container@ligo-webide-thing.service";
+        options = [ "NOPASSWD" ];
+      }];
+    }
+  ];
+
+  users.groups.deploy = {};
 
   containers.ligo-webide-thing = {
     autoStart = true;
     config = {
       imports = [ inputs.ligo-webide.nixosModules.default ];
-      services.ligo-webide.enable = true;
+      services.ligo-webide = {
+        enable = true;
+        package = "${profile-root}/backend";
+        ligo-package = "${profile-root}/ligo";
+        tezos-client-package = "${profile-root}/tezos-client";
+      };
       services.ligo-webide-frontend = {
         serverName = "localhost";
         enable = true;
+        package = "${profile-root}/frontend";
       };
     };
+    bindMounts."${profile-root}".hostPath = "${profile-root}";
     ephemeral = true;
     privateNetwork = true;
     hostAddress = "192.168.100.10";


### PR DESCRIPTION
Problem: Currently deployed webide version is outdated.

Solution: Update flake to use the newest version.

Currently based on https://gitlab.com/serokell/ligo/ligo/-/merge_requests/438