### PR TITLE
Grant webide team access to the tejat-prior

### DIFF
--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -20,6 +20,8 @@ with lib;
     openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINBuEKUhfJWZXUqgE2hN+aekbRj5yU8Q0kT4FjducocP webide" ];
   };
 
+  serokell-users.wheelUsers = [ "sashasashasasha151" "pgujjula" ];
+
   security.sudo.extraRules = [
     {
       users = [ "deploy" ];


### PR DESCRIPTION
Problem: Webide team members cannot deploy new webide versions from their machines, also they cannot observe logs and other info since they lack access to the server.

Solution: Grant Sasha and Preetham root access to the tejat-prior server.