### PR TITLE
[LIGO-946] Provide gist management token for our webide deployment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1659725433,
-        "narHash": "sha256-1ZxuK67TL29YLw88vQ18Y2Y6iYg8Jb7I6/HVzmNB6nM=",
+        "lastModified": 1668797197,
+        "narHash": "sha256-0w6iD3GSSQbIeSFVDzAAQZB+hDq670ZTms3d9XI+BtM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "41f15759dd8b638e7b4f299730d94d5aa46ab7eb",
+        "rev": "2a3c5f70eee04a465aa534d8bd4fcc9bb3c4a8ce",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1659725433,
-        "narHash": "sha256-1ZxuK67TL29YLw88vQ18Y2Y6iYg8Jb7I6/HVzmNB6nM=",
+        "lastModified": 1668797197,
+        "narHash": "sha256-0w6iD3GSSQbIeSFVDzAAQZB+hDq670ZTms3d9XI+BtM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "41f15759dd8b638e7b4f299730d94d5aa46ab7eb",
+        "rev": "2a3c5f70eee04a465aa534d8bd4fcc9bb3c4a8ce",
         "type": "github"
       },
       "original": {
@@ -670,11 +670,11 @@
       },
       "locked": {
         "dir": "tools/webide-new",
-        "lastModified": 1669854380,
-        "narHash": "sha256-Ro164LxZ8QrpaFy/1KilxWAmhXCyLLXHY57b66lbIQ0=",
+        "lastModified": 1671621857,
+        "narHash": "sha256-jMFApHeXxtdJAnMYq5uhUuu0FA2tUFT1IEfoxWr1pEM=",
         "ref": "refs/heads/tooling",
-        "rev": "2d69da4de33eaf0aa83a3df3ef4c9948ffc765fb",
-        "revCount": 12320,
+        "rev": "82325d5f41a2f52621664234093cf1627733d9de",
+        "revCount": 12754,
         "type": "git",
         "url": "https://gitlab.com/serokell/ligo/ligo?dir=tools%2fwebide-new"
       },

--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -41,15 +41,15 @@ with lib;
       imports = [ inputs.ligo-webide.nixosModules.default ];
       services.ligo-webide = {
         enable = true;
-        package = "${profile-root}/backend";
-        ligo-package = "${profile-root}/ligo";
-        tezos-client-package = "${profile-root}/tezos-client";
+        package = "${profile-root}/webide/backend";
+        ligo-package = "${profile-root}/webide/ligo";
+        tezos-client-package = "${profile-root}/webide/tezos-client";
         gist-token = "/run/gist-token";
       };
       services.ligo-webide-frontend = {
         serverName = "localhost";
         enable = true;
-        package = "${profile-root}/frontend";
+        package = "${profile-root}/webide/frontend";
       };
       services.prometheus.exporters.node = {
         enable = true;

--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -1,6 +1,7 @@
 { modulesPath, inputs, config, pkgs, lib, ... }:
 let
   profile-root = "/nix/var/nix/profiles/per-user/deploy";
+  vs = config.vault-secrets.secrets;
 in
 with lib;
 {
@@ -43,6 +44,7 @@ with lib;
         package = "${profile-root}/backend";
         ligo-package = "${profile-root}/ligo";
         tezos-client-package = "${profile-root}/tezos-client";
+        gist-token = "/run/gist-token";
       };
       services.ligo-webide-frontend = {
         serverName = "localhost";
@@ -58,6 +60,7 @@ with lib;
       networking.firewall.allowedTCPPorts = [ 9100 ];
     };
     bindMounts."${profile-root}".hostPath = "${profile-root}";
+    bindMounts."/run/gist-token".hostPath = "${vs.webide}/gist-token";
     ephemeral = true;
     privateNetwork = true;
     hostAddress = "192.168.100.10";
@@ -67,6 +70,8 @@ with lib;
   networking.nat.enable = true;
   networking.nat.internalInterfaces = ["ve-+"];
   networking.nat.externalInterface = "ens5";
+
+  vault-secrets.secrets.webide = {};
 
   services.nginx = {
     enable = true;


### PR DESCRIPTION
Problem: Webide now needs a token for gist management. We need to securely
provide a such token for our webide deployment.

Solution: Provide gist as a vault secret.

Currently based on https://gitlab.com/serokell/ligo/ligo/-/merge_requests/544.