### PR TITLE
[LIGO-977] Add cors-proxy instance for webide

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,7 +139,7 @@
     "deploy-rs_3": {
       "inputs": {
         "flake-compat": "flake-compat_9",
-        "nixpkgs": "nixpkgs_15",
+        "nixpkgs": "nixpkgs_16",
         "utils": "utils_3"
       },
       "locked": {
@@ -852,6 +852,24 @@
         "type": "github"
       }
     },
+    "nix-npm-buildpackage_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_14"
+      },
+      "locked": {
+        "lastModified": 1670813451,
+        "narHash": "sha256-v0IvQ35CMKtPreGlxWb1FvFUraJNZd144+MbiDwGoAA=",
+        "owner": "serokell",
+        "repo": "nix-npm-buildpackage",
+        "rev": "ec0365cd14a3359a23b80a9e2531a09afc3488fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "nix-npm-buildpackage",
+        "type": "github"
+      }
+    },
     "nix-unstable": {
       "inputs": {
         "lowdown-src": "lowdown-src_3",
@@ -916,7 +934,7 @@
     "nix_4": {
       "inputs": {
         "lowdown-src": "lowdown-src_5",
-        "nixpkgs": "nixpkgs_16"
+        "nixpkgs": "nixpkgs_17"
       },
       "locked": {
         "lastModified": 1633098935,
@@ -934,7 +952,7 @@
     "nix_5": {
       "inputs": {
         "lowdown-src": "lowdown-src_6",
-        "nixpkgs": "nixpkgs_18"
+        "nixpkgs": "nixpkgs_19"
       },
       "locked": {
         "lastModified": 1633098935,
@@ -1189,6 +1207,20 @@
     },
     "nixpkgs_14": {
       "locked": {
+        "lastModified": 1653917367,
+        "narHash": "sha256-04MsJC0g9kE01nBuXThMppZK+yvCZECQnUaZKSU+HJo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "437c8e6554911095f0557d524e9d2ffe1c26e33a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_15": {
+      "locked": {
         "lastModified": 1667318090,
         "narHash": "sha256-AvxgT+t1BWZs8IfdseHl8+7wvWWm9pvysupMT9wXdH0=",
         "owner": "serokell",
@@ -1201,7 +1233,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_15": {
+    "nixpkgs_16": {
       "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
@@ -1217,7 +1249,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_16": {
+    "nixpkgs_17": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -1229,25 +1261,25 @@
       "original": {
         "id": "nixpkgs",
         "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_17": {
-      "locked": {
-        "lastModified": 1632495107,
-        "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
-        "owner": "serokell",
-        "repo": "nixpkgs",
-        "rev": "be220b2dc47092c1e739bf6aaf630f29e71fe1c4",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
         "type": "indirect"
       }
     },
     "nixpkgs_18": {
       "locked": {
+        "lastModified": 1632495107,
+        "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "rev": "be220b2dc47092c1e739bf6aaf630f29e71fe1c4",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_19": {
+      "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
@@ -1258,20 +1290,6 @@
       "original": {
         "id": "nixpkgs",
         "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_19": {
-      "locked": {
-        "lastModified": 1632495107,
-        "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
-        "owner": "serokell",
-        "repo": "nixpkgs",
-        "rev": "be220b2dc47092c1e739bf6aaf630f29e71fe1c4",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
         "type": "indirect"
       }
     },
@@ -1282,6 +1300,20 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "8aeaba64d757e5cc626ac525f7504308de83741f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_20": {
+      "locked": {
+        "lastModified": 1632495107,
+        "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "rev": "be220b2dc47092c1e739bf6aaf630f29e71fe1c4",
         "type": "github"
       },
       "original": {
@@ -1498,7 +1530,8 @@
         "hermetic": "hermetic",
         "ligo-webide": "ligo-webide",
         "nix": "nix_3",
-        "nixpkgs": "nixpkgs_14",
+        "nix-npm-buildpackage": "nix-npm-buildpackage_2",
+        "nixpkgs": "nixpkgs_15",
         "serokell-nix": "serokell-nix_2",
         "stevenblack-hosts": "stevenblack-hosts",
         "subspace": "subspace",
@@ -1533,7 +1566,7 @@
         "flake-utils": "flake-utils_8",
         "gitignore-nix": "gitignore-nix_2",
         "nix": "nix_4",
-        "nixpkgs": "nixpkgs_17"
+        "nixpkgs": "nixpkgs_18"
       },
       "locked": {
         "lastModified": 1666982138,
@@ -1694,7 +1727,7 @@
         "flake-compat": "flake-compat_11",
         "flake-utils": "flake-utils_10",
         "nix": "nix_5",
-        "nixpkgs": "nixpkgs_19"
+        "nixpkgs": "nixpkgs_20"
       },
       "locked": {
         "lastModified": 1655914948,

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,11 @@
     };
 
     ligo-webide.url = "git+https://gitlab.com/serokell/ligo/ligo?dir=tools/webide-new";
+    nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };
 
   outputs = { self, nix, nixpkgs, serokell-nix, deploy-rs, flake-utils, vault-secrets
-    , composition-c4, ... }@inputs:
+    , composition-c4, nix-npm-buildpackage, ... }@inputs:
     let
       inherit (nixpkgs.lib) nixosSystem filterAttrs const recursiveUpdate;
       inherit (builtins) readDir mapAttrs;
@@ -33,6 +34,7 @@
         vault-secrets.overlay
         composition-c4.overlays.default
         self.overlay
+        nix-npm-buildpackage.overlays.default
       ];
 
       servers = mapAttrs (path: _: import (./servers + "/${path}"))

--- a/modules/cors-proxy.nix
+++ b/modules/cors-proxy.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+let
+  cors-proxy = (pkgs.extend (self: super: {nodejs = super.nodejs-14_x;})).buildNpmPackage {
+    src = pkgs.fetchFromGitHub {
+      owner = "isomorphic-git";
+      repo = "cors-proxy";
+      # v2.7.1
+      rev = "1b1c91e71d946544d97ccc7cf0ac62b859e03311";
+      sha256 = "sha256-YnSYVeq9Irc2QexvSuE7wq+hi8OGZhlLE2JlbRqzMi4=";
+    };
+    postInstall = ''
+      wrapProgram $out/bin/npm --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ nodejs-14_x ])}
+    '';
+  };
+  cfg = config.services.cors-proxy;
+in {
+  options.services.cors-proxy = with lib; {
+    enable = mkEnableOption "Enable @isomorphic-git/cors-proxy";
+    package = mkOption {
+      type = types.package;
+      default = cors-proxy;
+    };
+    port = mkOption {
+      type = types.int;
+      default = 9999;
+      description = ''
+        The port to listen to.
+      '';
+    };
+    allowOrigin = mkOption {
+      type = types.str;
+      default = "*";
+      description = ''
+        The value for the 'Access-Control-Allow-Origin' CORS header.
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.ligo-webide-cors-proxy = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${cfg.package}/bin/npm start
+      '';
+      environment = {
+        PORT = toString cfg.port;
+        ALLOW_ORIGIN = cfg.allowOrigin;
+      };
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,3 +1,4 @@
 {
   mtg = import ./mtg.nix;
+  cors-proxy = import ./cors-proxy.nix;
 }

--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -2,11 +2,15 @@
 let
   profile-root = "/nix/var/nix/profiles/per-user/deploy";
   vs = config.vault-secrets.secrets;
+  ports = {
+    cors-proxy = 9999;
+  };
 in
 with lib;
 {
   imports = [
     inputs.serokell-nix.nixosModules.ec2
+    inputs.self.nixosModules.cors-proxy
   ];
 
   networking.firewall =
@@ -82,6 +86,16 @@ with lib;
       forceSSL = true;
       locations."/".proxyPass = "http://192.168.100.11:80";
     };
+    virtualHosts."ligo-webide-cors-proxy.serokell.team" = {
+      enableACME = true;
+      forceSSL = true;
+      locations."/".proxyPass = "http://127.0.0.1:${toString ports.cors-proxy}";
+    };
+  };
+
+  services.cors-proxy = {
+    enable = true;
+    port = ports.cors-proxy;
   };
 
   services.murmur =

--- a/terraform/tejat-prior.tf
+++ b/terraform/tejat-prior.tf
@@ -64,3 +64,11 @@ resource "aws_route53_record" "ligo_webide_cname" {
   ttl     = "60"
   records = [aws_route53_record.tejat-prior_gemini_serokell_team_ipv4.name]
 }
+
+resource "aws_route53_record" "ligo_webide_cors_proxy_cname" {
+  zone_id = data.aws_route53_zone.serokell_team.zone_id
+  name    = "ligo-webide-cors-proxy.${data.aws_route53_zone.serokell_team.name}"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [aws_route53_record.tejat-prior_gemini_serokell_team_ipv4.name]
+}


### PR DESCRIPTION
Problem: Webide needs [cors-proxy](https://github.com/isomorphic-git/cors-proxy) to successfully handle interaction with git repositories.

Solution:
1) Provide cors-proxy instance on tejat-prior.
2) Add ligo-webide-cors-proxy.serokell.team CNAME
   that points to tejat-prior.
3) Update nginx to proxy requests on
   https://ligo-webide-cors-proxy.serokell.team to cors-proxy.