### PR TITLE
[LIGO-976] Allow 'deploy' user run commands inside webide container 

### DIFF
--- a/servers/tejat-prior/default.nix
+++ b/servers/tejat-prior/default.nix
@@ -31,7 +31,7 @@ with lib;
     {
       users = [ "deploy" ];
       commands = [{
-        command = "/run/current-system/sw/bin/systemctl restart container@ligo-webide-thing.service";
+        command = "/run/current-system/sw/bin/nixos-container run ligo-webide-thing -- *";
         options = [ "NOPASSWD" ];
       }];
     }


### PR DESCRIPTION
Problem: Currently webide activation restarts the entire container and
as a result, it's non-trivial to catch services failures that may occur
after container restart. Webide activation profile now runs commands
inside this container. However, 'deploy' user doesn't have sufficient
priviliges to run such commands.

Solution: Add sudoers entry to allow 'deploy' user run commands inside
the webide container via 'nixos-container run ligo-webide-thing'.

Currently based on #66 