### PR TITLE
Add 'tt.serokell.io' to serverAliases

### DIFF
--- a/servers/alzirr/deployment.nix
+++ b/servers/alzirr/deployment.nix
@@ -75,6 +75,7 @@ in
         enableACME = true;
 
         serverName = "tt2.serokell.io";
+        serverAliases = [ "tt.serokell.io" ];
 
         locations."/" = {
           root = swampwalk2-frontend-profile;


### PR DESCRIPTION
Problem: oauth2 proxy redirects to 'tt.serokell.io', while this URL is no longer used and its certificate expired. As a result, users see an error in their browsers.

Solution: Add 'tt.serokell.io' to serverAliases of the nginx swampwalk virtual host.