### PR TITLE
Cleanup wg-keys.nix

### DIFF
--- a/servers/wasat/wg-keys.nix
+++ b/servers/wasat/wg-keys.nix
@@ -1,26 +1,26 @@
 {
   # (offboarded) "2" = "VxD6G/MJhuFGiJXL5ad5b8SSbC/kgzfQJjIvWFr6th4=";  # Yegor Timoshenko
-  "3"  = "yXXfdeMOAy2qNjZX5jumaAi2qGSb/YEqdqI+HYWO/ho="; # Maxim Koltsov
+  # (offboarded) "3"  = "yXXfdeMOAy2qNjZX5jumaAi2qGSb/YEqdqI+HYWO/ho="; # Maxim Koltsov
   "4"  = "Wi1CW3vJIvxYvdrbBh6TYGdNnDbu6AvhFXxpVoVGEUQ="; # Arseniy Seroka (phone)
   "5"  = "h/trC+5Z8qbGBJtroYITQGMNUn5XQZ/JRqVR3iIH5Ro="; # Rinat Stryungis (Windows - lenovo)
   #6   removed
   # (offboarded - HR-96) "7"  = "yn1o899Ib3PFJZph50YdK6N4Kiyl2vdL1coBLff1mhY="; # Lars Jellema
-  "8"  = "iebbc7JjKvxeNNyRi++Z6F8MRfQMD8NOg0xttUFj40U="; # Yorick van Pelt
-  "9"  = "h/trC+5Z8qbGBJtroYITQGMNUn5XQZ/JRqVR3iIH5Ro="; # Kyrill Briantsev
+  # (offboarded) "8"  = "iebbc7JjKvxeNNyRi++Z6F8MRfQMD8NOg0xttUFj40U="; # Yorick van Pelt
+  # (offboarded) "9"  = "h/trC+5Z8qbGBJtroYITQGMNUn5XQZ/JRqVR3iIH5Ro="; # Kyrill Briantsev
   # (offboarded) "10" = "cMc80F788JOdvWlPsQPnT1v9OJrECwTqqnmAPKVthAU="; # Allan Lukwago
   "11" = "9XA2K8ZAX+Ickgt76WiPr42IsMUkb1e5oyXBrhw/QQU="; # Arseniy Seroka (Mac)
   "12" = "4YJwhKgnXX/v+Fom9fOH4N/vbt46RBI0V2aZVowZtws="; # Arseniy Seroka (Mac 2)
   #13  removed
   "14" = "4KR6fzY0X1JxZtI3CsFyZ+gKHKRM27TGlILk1LBLzUM="; # Kostya Ivanov
-  "15" = "PWlDm/5alF9yjC7/xLCY+FQo0KhpLqV4kdgWoAgvN28="; # Ilya Lubimov
+  # (offboarded) "15" = "PWlDm/5alF9yjC7/xLCY+FQo0KhpLqV4kdgWoAgvN28="; # Ilya Lubimov
   "16" = "zHP2fnjWU7DlGjqPvXxJZgoUpJI/bsKSkb7xZAfanC8="; # Ivan Gromakovskii 1 (desktop computer)
   "17" = "wNLlDMF7HwTlRqOZzyjJCGrXNbrtIdjnYeOukTkOvRE="; # Ivan Gromakovskii 2 (mac)
   # (offboarded - HR-96) "18" = "2BYngjq0XIP6M2L1CItSFHg44s1UFohECVHOKloYOTI="; # Lars Jellema (phone)
-  "19" = "MdPb8n+oo9/JjYTg1QodjILQGhlxBvRpPfN5Oui/GFQ="; # jupiter.serokell.io
+  # (decommisioned) "19" = "MdPb8n+oo9/JjYTg1QodjILQGhlxBvRpPfN5Oui/GFQ="; # jupiter.serokell.io
   # (lost) "20" = "b56RX/RoeU5Cq4mQTym5JTnI5jvLZ2tnzvC7WO+Lekc="; # Ivan Gromakovskii 3 (phone)
-  "21" = "ZkM+PzUSglJ5QLUXLLslLKj2ew/zGQbLzRrRXS6briQ="; # Dmitrii Mukhutdinov 1 (thinkpad)
-  "22" = "BqqEzv8Whwn+3zM26gRj2Gf7dgTp/DkxFYfRqPoNZVs="; # Dmitrii Mukhutdinov 2 (macos)
-  "23" = "7Y+6DAQh0uQmkxbfASNe/Tz5qoq1FNBY/0lSAPPQTFg="; # Dmitrii Mukhutdinov 3 (ios)
+  # (offboarded) "21" = "ZkM+PzUSglJ5QLUXLLslLKj2ew/zGQbLzRrRXS6briQ="; # Dmitrii Mukhutdinov 1 (thinkpad)
+  # (offboarded) "22" = "BqqEzv8Whwn+3zM26gRj2Gf7dgTp/DkxFYfRqPoNZVs="; # Dmitrii Mukhutdinov 2 (macos)
+  # (offboarded) "23" = "7Y+6DAQh0uQmkxbfASNe/Tz5qoq1FNBY/0lSAPPQTFg="; # Dmitrii Mukhutdinov 3 (ios)
   # (offboarded) "24" = "Z2ktaCa9MySgC1hUlSg44Jx7iH/MWUC+1Ref2hJGC24="; # Konstantin Andriotis (ios)
   "26" = "wUpbbLu5PF5Q3j5OpAFCkuzXPqQRgLgiPyIHHPjkwCY="; # Vladislav Zavialov (Mac)
   # (offboarded) "27" = "57Df3FY2MQKQ0sMS/67r1L9k0gBhOQ4wqCJxRpuWNkE="; # Vasiliy Kevroletin 1 (linux laptop)
@@ -33,28 +33,28 @@
   "34" = "srEmFWWYhzhjWXtZ0ewU0cTyW329jizzT7ElDzBCqkg="; # Jonn Mostovoy (laboratory in latvia)
   # (offboarded - HR-88) "35" = "5KaouRvlfh45mG64iPXWw9uut4JemAtayJ9lotjEbQo="; # Damir Garifullin
   "36" = "mhsybC2wiwIlRIDIJYqZEE5aIR8S7fkNxIPIubcVtSU="; # office SPb (srkrt)
-  "37" = "NwZ6bfanB8RxPzsiPvCRId6N8JJLiyXTl6ZB/bfI80I="; # Ilya Peresadin (MacOS)
+  # (offboarded) "37" = "NwZ6bfanB8RxPzsiPvCRId6N8JJLiyXTl6ZB/bfI80I="; # Ilya Peresadin (MacOS)
   # (offboarded) "38" = "SSayDwgxJv6LFiMw72iPdKLT5PHTrRwx1ODk8Db9wxE="; # Paul Tsupikoff (phone)
   "39" = "2E/S/T+n53bbP0CV04uayrs6POZ9qZLrtl4Am26naVI="; # Rinat Stryungis (nixOS)
   # (offboarded) "40" = "oIZ4XLs9E/W8UzrTs+byJRBbgs5/HWQtNvP+et27o0w="; # Zhenya Vinogradov
   # (suspicious traffic) "41" = "uUZiefGUqrMWIFYhAd0oJRVCj3wQEoiYhEVr7ACXYSw="; # Anton Myasnikov (linux)
   # unused "42" = "6wXyIaig7Syeaj9+fW3J9IxRAYm1WxJKzuA9wEdwGGc="; # Roman Melnikov
-  "43" = "cFleIhfMaB5X+xqxNYrOXgRLqortiVgGzxVo4zkDwEY="; # Kirill Kuvshinov
-  "44" = "ecK/Hr5OhCuGwPDGnNeSFdaPJPAGOJ3gfyK3jeFazSY="; # Grigory Pevnev
+  # (offboarded) "43" = "cFleIhfMaB5X+xqxNYrOXgRLqortiVgGzxVo4zkDwEY="; # Kirill Kuvshinov
+  # (offboarded) "44" = "ecK/Hr5OhCuGwPDGnNeSFdaPJPAGOJ3gfyK3jeFazSY="; # Grigory Pevnev
   "45" = "e9HScVFEIG2HchvirXXDLg+wHjvcbxx9rp5Q/f8LewU="; # Aleksandr Pakulev
   "46" = "gOzFvhKvJQ1l1ukazaEtBxGlv9oD98HExDHzdAMdn3Q="; # Ivan Gromakovskii (lenovo laptop)
-  "47" = "YPi4GCRxt1qAQnb4uqYySTju9uDhxzZnTqme07lvfHs="; # Ilya Lubimov (win)
+  # (offboarded) "47" = "YPi4GCRxt1qAQnb4uqYySTju9uDhxzZnTqme07lvfHs="; # Ilya Lubimov (win)
   "48" = "NOSFd1t60ZF0ZTty2iq8IfNydKD1yfq5rP5SDaYGlCE="; # Diogo Castro
-  "49" = "OaSGqg6lMyX+7gXxl3vPVwgAMsInupcP39UODGa7tkE="; # Alexander Vereshchagin
+  # (offboarded) "49" = "OaSGqg6lMyX+7gXxl3vPVwgAMsInupcP39UODGa7tkE="; # Alexander Vereshchagin
   "50" = "X5ODBmbcLENAnqiXGVSel5IgSIHxL3nq3PRnYTBhgz4="; # Pasquale Pinto
   "51" = "eZldxihhLW8bIhUt2GCAQSAMXU3PYO7Az4w8rKg0TBE="; # Jonn Mostovoy (work laptop)
   "52" = "KSK3+6TuGRyf9xe49C5+q2VhWYhWBbsm+B8UMDxFg3Y="; # Alexander Bantyev @balsoft
   "53" = "wPKA+1WYVAF6QhlLSJAZsk49I0YkoljGaQyA/AgWsjo="; # Alexey Khachiyants (Mac)
   "54" = "noNARSZ3ARTol2/UT4fq5UlM5FR8dtcxSuq7E/zWWSA="; # Dmitri Puzyrev (ubuntu)
-  "55" = "qW2StgTSXBfmqo9++Bde76UZegv4gKH+wnR9eNmTRhw="; # Andrey Demidenko (tarvos)
-  "56" = "sW7lM1ARU3SyDIybTKoBcnUduNBkC4q3MmQFwtVbySw="; # Andrey Demidenko (phone)
+  # (offboarded) "55" = "qW2StgTSXBfmqo9++Bde76UZegv4gKH+wnR9eNmTRhw="; # Andrey Demidenko (tarvos)
+  # (offboarded) "56" = "sW7lM1ARU3SyDIybTKoBcnUduNBkC4q3MmQFwtVbySw="; # Andrey Demidenko (phone)
   "57" = "yiA60l8EXtBope5DSpRScCKLWRDesyShPlGXPP3tjD8="; # Ivan Gromakovskii (phone)
-  "58" = "H6/j+dLXJgY8ht7NcWRQDvh60XLxxGGlvoFXw1pcMQg="; # Andreev Kirill (linux desktop)
+  # (offboarded) "58" = "H6/j+dLXJgY8ht7NcWRQDvh60XLxxGGlvoFXw1pcMQg="; # Andreev Kirill (linux desktop)
   "59" = "VCaUxUR3D81o2SkKHfER3pbMkbo/LP5FzxXY6A3lYFM="; # Roman Melnikov (linux laptop)
   # (offboarded) "60" = "MikaZY25dY7DSj4NIRr38thFlPAEDZ0BGEXGb+P8Pjk="; # Mika Logan (NixOS laptop)
   "61" = "88+XZWfgi0QRc19dUPjgZi/1BzsbRrxVOBOku1OHqUc="; # HQ (mac mini M1)


### PR DESCRIPTION
Problem: wg-keys.nix configures VPN clients for people who no longer work with us.

Solution: Remove such people from the VPN config.