### PR TITLE
[Chore] Update tejat-prior function in README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All necessary programs and dependencies are provided by Nix in `nix-shell` or `n
 | Jishui      | EDNA Demo             |               |
 | Mebsuta     | vpn.serokell.net      |               |
 | Mekbuda     | MTProxy server        |               |
-| Tejat Prior | Mumble + Ligo Web IDE |               |
+| Tejat Prior | Mumble + tzbot        |               |
 | Wasat       | Old Wireguard server  |               |
 
 <!-- Don't forget to add the servers on https://www.notion.so/serokell/Server-Naming-Scheme-c189819000164fb090377c75e4ce7da6 -->


### PR DESCRIPTION
Problem: Tejat-prior no longer runs webide, but runs tzbot instance.

Solution: Update README table.