### PR TITLE
[OPS-1422] Add name tags for AWS instances

### DIFF
--- a/terraform/alhena.tf
+++ b/terraform/alhena.tf
@@ -25,6 +25,9 @@ resource "aws_instance" "alhena" {
     volume_type = "gp2"
     volume_size = "20"
   }
+  tags = {
+    Name = "alhena"
+  }
 }
 
 # Public DNS

--- a/terraform/castor.tf
+++ b/terraform/castor.tf
@@ -24,6 +24,9 @@ resource "aws_instance" "castor" {
     volume_type = "gp2"
     volume_size = "30"
   }
+  tags = {
+    Name = "castor"
+  }
 }
 
 # Public DNS

--- a/terraform/jishui.tf
+++ b/terraform/jishui.tf
@@ -24,6 +24,9 @@ resource "aws_instance" "jishui" {
     volume_type = "gp2"
     volume_size = "30"
   }
+  tags = {
+    Name = "jishui"
+  }
 }
 
 # Public DNS

--- a/terraform/mekbuda.tf
+++ b/terraform/mekbuda.tf
@@ -24,6 +24,9 @@ resource "aws_instance" "mekbuda" {
     volume_type = "gp2"
     volume_size = "20"
   }
+  tags = {
+    Name = "mekbuda"
+  }
 }
 
 # Public DNS

--- a/terraform/tejat-prior.tf
+++ b/terraform/tejat-prior.tf
@@ -25,6 +25,9 @@ resource "aws_instance" "tejat-prior" {
     volume_type = "gp2"
     volume_size = "40"
   }
+  tags = {
+    Name = "tejat-prior"
+  }
 }
 
 # Public DNS


### PR DESCRIPTION
Problem: We need to analyze AWS expenses for instances in this repo. Unfortunately, the only viable way to filter expenses reports is to add name tags to instances.

Solution: Add name tags to AWS instances.