### PR TITLE
[Chore] Refactor DNS records

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1874,11 +1874,11 @@
         "vpcModule": "vpcModule"
       },
       "locked": {
-        "lastModified": 1681460124,
-        "narHash": "sha256-Ns40PPDcV1ebh188pxCCnwFdVoLHDJwiSSO9sylCQ2g=",
+        "lastModified": 1681908195,
+        "narHash": "sha256-ne+Bo7GVPUPm7eIuIcWPN8Y1JrqucLyqgKcnCiwHI5c=",
         "ref": "refs/heads/main",
-        "rev": "1643e1a514e8ddbc3289770c39fd38eae309a3ba",
-        "revCount": 8,
+        "rev": "a6f1947a07669738cf2503668d912da53c8d0ce6",
+        "revCount": 14,
         "type": "git",
         "url": "ssh://git@github.com/serokell/terranix-simple"
       },

--- a/terraform/alzirr.nix
+++ b/terraform/alzirr.nix
@@ -1,20 +1,8 @@
-{ lib, ... }:
-{
+{ pkgs, lib, ... }:
+let
+  inherit (pkgs.lib) mkAddressRecords;
+in {
   resource.aws_route53_record = lib.mapAttrs (_: lib.recursiveUpdate { ttl = "60"; }) {
-    alzirr_gemini_serokell_team_ipv4 = {
-      zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
-      name = "alzirr.gemini.serokell.team";
-      type = "A";
-      records = ["135.181.78.88"];
-    };
-
-    alzirr_gemini_serokell_team_ipv6 = {
-      zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
-      name = "alzirr.gemini.serokell.team";
-      type = "AAAA";
-      records = ["2a01:4f9:4b:1667::1"];
-    };
-
     tt_serokell_io = {
       zone_id = "\${data.aws_route53_zone.serokell_io.zone_id}";
       name = "tt.serokell.io";
@@ -28,5 +16,11 @@
       type = "CNAME";
       records = ["alzirr.\${aws_route53_zone.gemini_serokell_team.name}"];
     };
-  };
+  } // mkAddressRecords [{
+    resource = "alzirr_gemini_serokell_team";
+    zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
+    name = "alzirr.gemini.serokell.team";
+    ipv4_records = ["135.181.78.88"];
+    ipv6_records = ["2a01:4f9:4b:1667::1"];
+  }];
 }

--- a/terraform/castor.nix
+++ b/terraform/castor.nix
@@ -1,6 +1,7 @@
-{ lib, ... }:
+{ pkgs, lib, ... }:
 let
   inherit (import ./common.nix) mkAWS;
+  inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.aws_instance.castor = mkAWS {
     key_name = "balsoft"; # eu-west-2
@@ -17,26 +18,19 @@ in {
     vpc = true;
   };
 
-  resource.aws_route53_record = lib.mapAttrs (_: lib.recursiveUpdate { ttl = "60"; }) {
-    castor_gemini_serokell_team_ipv4 = {
-      zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
-      name = "castor.\${aws_route53_zone.gemini_serokell_team.name}";
-      type = "A";
-      records = ["\${aws_eip.castor.public_ip}"];
-    };
-
+  resource.aws_route53_record = {
     staging_edna_cname = {
       zone_id = "\${data.aws_route53_zone.serokell_team.zone_id}";
       name = "staging.edna.\${data.aws_route53_zone.serokell_team.name}";
       type = "CNAME";
+      ttl = "60";
       records = ["\${aws_route53_record.castor_gemini_serokell_team_ipv4.name}"];
     };
-
-    castor_gemini_serokell_team_ipv6 = {
-      zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
-      name = "castor.\${aws_route53_zone.gemini_serokell_team.name}";
-      type = "AAAA";
-      records = ["\${aws_instance.castor.ipv6_addresses[0]}"];
-    };
-  };
+  } // mkAddressRecords [{
+    resource = "castor_gemini_serokell_team";
+    zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
+    name = "castor.\${aws_route53_zone.gemini_serokell_team.name}";
+    ipv4_records = ["\${aws_eip.castor.public_ip}"];
+    ipv6_records = ["\${aws_instance.castor.ipv6_addresses[0]}"];
+  }];
 }

--- a/terraform/jishui.nix
+++ b/terraform/jishui.nix
@@ -1,6 +1,7 @@
-{ lib, ... }:
+{ pkgs, lib, ... }:
 let
   inherit (import ./common.nix) mkAWS;
+  inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.aws_instance.jishui = mkAWS {
     key_name = "Chris"; # eu-west-2
@@ -17,26 +18,19 @@ in {
     vpc = true;
   };
 
-  resource.aws_route53_record = lib.mapAttrs (_: lib.recursiveUpdate { ttl = "60"; }) {
-    jishui_gemini_serokell_team_ipv4 = {
-      zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
-      name = "jishui.\${aws_route53_zone.gemini_serokell_team.name}";
-      type = "A";
-      records = ["\${aws_eip.jishui.public_ip}"];
-    };
-
+  resource.aws_route53_record = {
     demo_edna_cname = {
       zone_id = "\${data.aws_route53_zone.serokell_team.zone_id}";
       name = "demo.edna.\${data.aws_route53_zone.serokell_team.name}";
       type = "CNAME";
+      ttl = "60";
       records = ["\${aws_route53_record.jishui_gemini_serokell_team_ipv4.name}"];
     };
-
-    jishui_gemini_serokell_team_ipv6 = {
-      zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
-      name = "jishui.\${aws_route53_zone.gemini_serokell_team.name}";
-      type = "AAAA";
-      records = ["\${aws_instance.jishui.ipv6_addresses[0]}"];
-    };
-  };
+  } // mkAddressRecords [{
+    resource = "jishui_gemini_serokell_team";
+    zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
+    name = "jishui.\${aws_route53_zone.gemini_serokell_team.name}";
+    ipv4_records = ["\${aws_eip.jishui.public_ip}"];
+    ipv6_records = ["\${aws_instance.jishui.ipv6_addresses[0]}"];
+  }];
 }

--- a/terraform/wasat.nix
+++ b/terraform/wasat.nix
@@ -1,39 +1,28 @@
-{ lib, ... }:
-let inherit (import ./common.nix) mkHcloud;
+{ pkgs, lib, ... }:
+let
+  inherit (import ./common.nix) mkHcloud;
+  inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.hcloud_server.wasat = mkHcloud {
     name = "wasat";
     ssh_keys = ["\${hcloud_ssh_key.zhenya.id}"];
   };
 
-  resource.aws_route53_record = lib.mapAttrs (_: lib.recursiveUpdate { ttl = "60"; }) {
-    wasat_gemini_serokell_team_ipv4 = {
+  resource.aws_route53_record = mkAddressRecords [
+    {
+      resource = "wasat_gemini_serokell_team";
       zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
       name = "wasat.\${aws_route53_zone.gemini_serokell_team.name}";
-      type = "A";
-      records = ["\${hcloud_server.wasat.ipv4_address}"];
-    };
-
-    wasat_gemini_serokell_team_ipv6 = {
-      zone_id = "\${aws_route53_zone.gemini_serokell_team.zone_id}";
-      name = "wasat.\${aws_route53_zone.gemini_serokell_team.name}";
-      type = "AAAA";
-      records = ["\${hcloud_server.wasat.ipv6_address}"];
-    };
-
+      ipv4_records = ["\${hcloud_server.wasat.ipv4_address}"];
+      ipv6_records = ["\${hcloud_server.wasat.ipv6_address}"];
+    }
     # serokell.net DNS records (can't be a CNAME becase it's a zone apex)
-    serokell_net_ipv4 = {
+    {
+      resource = "serokell_net";
       zone_id = "\${data.aws_route53_zone.serokell_net.zone_id}";
       name = "serokell.net";
-      type = "A";
-      records = ["\${hcloud_server.wasat.ipv4_address}"];
-    };
-
-    serokell_net_ipv6 = {
-      zone_id = "\${data.aws_route53_zone.serokell_net.zone_id}";
-      name = "serokell.net";
-      type = "AAAA";
-      records = ["\${hcloud_server.wasat.ipv6_address}"];
-    };
-  };
+      ipv4_records = ["\${hcloud_server.wasat.ipv4_address}"];
+      ipv6_records = ["\${hcloud_server.wasat.ipv6_address}"];
+    }
+  ];
 }


### PR DESCRIPTION
Problem: We have added the mkAddressRecords function to terranix-simple, so now we can reduce amount of boilerplate when defining DNS records for ipv4 and ipv6.

Solution: Use mkAddressRecords to refactor DNS records.