### PR TITLE
[Chore] Refactor aws instances and hcloud servers

### DIFF
--- a/terraform/alhena.nix
+++ b/terraform/alhena.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  inherit (import ./common.nix) mkAWS;
+  inherit (import ./common.nix pkgs) mkAWS;
   inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.aws_instance.alhena = mkAWS {

--- a/terraform/castor.nix
+++ b/terraform/castor.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  inherit (import ./common.nix) mkAWS;
+  inherit (import ./common.nix pkgs) mkAWS;
   inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.aws_instance.castor = mkAWS {

--- a/terraform/common.nix
+++ b/terraform/common.nix
@@ -1,35 +1,16 @@
-{
-  mkAWS = let
-    security-group = [
-      "\${aws_security_group.egress_all.id}"
-      "\${aws_security_group.http.id}"
-      "\${aws_security_group.ssh.id}"
-      "\${aws_security_group.wireguard.id}"
-    ]; in {key_name, volume_size, tags, vpc_security_group_ids ? security-group}: {
-      # Networking
-      availability_zone = "\${module.vpc.azs[2]}";
-      subnet_id = "\${module.vpc.public_subnets[2]}";
-      associate_public_ip_address = true;
-      inherit key_name tags vpc_security_group_ids;
+{ pkgs, ... }:
+let
+  inherit (pkgs.lib) mkAWS mkHcloud;
+in {
+  mkAWS = {key_name, volume_size, tags, vpc_security_group_ids ? null}@args: mkAWS ({
+    availability_zone = "\${module.vpc.azs[2]}";
+    subnet_id = "\${module.vpc.public_subnets[2]}";
+    instance_type = "t3a.micro";
+  } // args);
 
-      # Instance parameters
-      instance_type = "t3a.micro";
-      monitoring = true;
-
-      # Disk type, size, and contents
-      lifecycle.ignore_changes = [ "ami" ];
-      ami = "\${data.aws_ami.nixos.id}";
-      root_block_device = {
-        volume_type = "gp2";
-        inherit volume_size;
-      };
-    };
-
-  mkHcloud = {name, ssh_keys}: {
+  mkHcloud = {name, ssh_keys}: mkHcloud {
     inherit name ssh_keys;
-    image = "ubuntu-20.04";
     server_type = "cx11";
-    lifecycle.ignore_changes = [ "user_data" ];
     # Install NixOS 20.09
     user_data = ''
     #cloud-config

--- a/terraform/jishui.nix
+++ b/terraform/jishui.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  inherit (import ./common.nix) mkAWS;
+  inherit (import ./common.nix pkgs) mkAWS;
   inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.aws_instance.jishui = mkAWS {

--- a/terraform/mebsuta.nix
+++ b/terraform/mebsuta.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  inherit (import ./common.nix) mkHcloud;
+  inherit (import ./common.nix pkgs) mkHcloud;
   inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.hcloud_server.mebsuta = mkHcloud {

--- a/terraform/tejat-prior.nix
+++ b/terraform/tejat-prior.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  inherit (import ./common.nix) mkAWS;
+  inherit (import ./common.nix pkgs) mkAWS;
   inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.aws_instance.tejat-prior = mkAWS {

--- a/terraform/wasat.nix
+++ b/terraform/wasat.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  inherit (import ./common.nix) mkHcloud;
+  inherit (import ./common.nix pkgs) mkHcloud;
   inherit (pkgs.lib) mkAddressRecords;
 in {
   resource.hcloud_server.wasat = mkHcloud {


### PR DESCRIPTION
Problem: We have added the mkAWS and mkHcloud to terranix-simple, so now we can reduce amount of boilerplate when defining aws instances and hcloud servers.

Solution: Use mkAWS and mkHcloud to refactor aws instances and hcloud servers.