### PR TITLE
Disable DNS64

### DIFF
--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -39,6 +39,11 @@ in {
     };
   };
 
+  module.vpc = {
+    public_subnet_enable_dns64 = false;
+    public_subnet_enable_resource_name_dns_aaaa_record_on_launch = false;
+  };
+
   resource.aws_key_pair.balsoft = {
     key_name = "balsoft";
     public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd2OdcSHUsgezuV+cpFqk9+Svtup6PxIolv1zokVZdqvS8qxLsA/rwYmQgTnuq4/zK/GIxcUCH4OxYlW6Or4M4G7qrDKcLAUrRPWkectqEooWRflZXkfHduMJhzeOAsBdMfYZQ9024GwKr/4yriw2BGa8GbbAnQxiSeTipzvXHoXuRME+/2GsMFAfHFvxzXRG7dNOiLtLaXEjUPUTcw/fffKy55kHtWxMkEvvcdyR53/24fmO3kLVpEuoI+Mp1XFtX3DvRM9ulgfwZUn8/CLhwSLwWX4Xf9iuzVi5vJOJtMOktQj/MwGk4tY/NPe+sIk+nAUKSdVf0y9k9JrJT98S/ cardno:000610645773";


### PR DESCRIPTION
Problem: DNS64 needs a dedicated route for domains that don't have IPv6 record. This route is not provided by the VPC module, thus resolving doesn't work.

Solution: Disable DNS64.