### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
       server-matrix: ${{ steps.set-server-matrix.outputs.matrix }}
       check-matrix: ${{ steps.set-check-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: set-server-matrix
         run: echo "matrix=$(nix eval --json .#server-matrix.x86_64-linux)" >> $GITHUB_OUTPUT
@@ -25,7 +25,7 @@ jobs:
       # this matrix consists of the names of all checks defined in flake.nix
       matrix: ${{fromJson(needs.get-matrices.outputs.check-matrix)}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: check
         run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
@@ -39,7 +39,7 @@ jobs:
       # this matrix consists of the names of all servers located in the ./servers directory
       matrix: ${{fromJson(needs.get-matrices.outputs.server-matrix)}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: build
         run: nix build -L .#deploy.nodes.${{ matrix.server }}.profiles.system.path


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs
no longer supports this runtime. However, "actions/checkout@v3" uses
this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".
