### PR TITLE
[OPS-1402] Add systemd unit restart policy

### DIFF
--- a/modules/cors-proxy.nix
+++ b/modules/cors-proxy.nix
@@ -45,6 +45,12 @@ in {
       script = ''
         ${cfg.package}/bin/@isomorphic-git/cors-proxy start
       '';
+      startLimitBurst = 5;
+      startLimitIntervalSec = 300;
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 10;
+      };
       environment = {
         PORT = toString cfg.port;
         ALLOW_ORIGIN = cfg.allowOrigin;


### PR DESCRIPTION
Problem: By default, systemd services generated from the NixOS system configuration don't attempt to restart on failure since Restart=no. However, in some cases, running processes can fail for unclear reasons, and the simplest way to bring the failed service back to life is to restart it. Instead, currently, the service will fail and trigger an alert without attempting to restart.

Solution: Add default values for startLimitBurst, startLimitIntervalSec, Restart, and RestartSec.