### PR TITLE
[OPS-1161] Harden systemd services

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -4,6 +4,7 @@
     inputs.serokell-nix.nixosModules.serokell-users
     inputs.vault-secrets.nixosModules.vault-secrets
     inputs.serokell-nix.nixosModules.wireguard-monitoring
+    inputs.serokell-nix.lib.systemd.hardenServices
   ];
 
   networking.domain = "gemini.serokell.team";

--- a/servers/alzirr/deployment.nix
+++ b/servers/alzirr/deployment.nix
@@ -39,6 +39,28 @@ in
       User = "sweater";
       Group = "users";
       ExecStart = "${swampwalk2-profile}/bin/swampwalk-server";
+
+      # hardening options
+      CapabilityBoundingSet = [
+        "CAP_CHOWN"
+        "CAP_SETUID"
+        "CAP_SETGID"
+        "CAP_FOWNER"
+        "CAP_DAC_OVERRIDE"
+      ];
+      AmbientCapabilities = [ "" ];
+      DeviceAllow = "no";
+      KeyringMode = "private";
+      NotifyAccess = "none";
+      PrivateMounts = "yes";
+      PrivateTmp = "yes";
+      ProtectControlGroups = "yes";
+      ProtectProc = "invisible";
+      SupplementaryGroups = [ "" ];
+      Delegate = "no";
+      RemoveIPC = "yes";
+      UMask = "0027";
+      ProcSubset = "pid";
     };
   };
 


### PR DESCRIPTION
Problem: We want to harden the security of our systemd services.

Solution: Update hardened services, harden swampwalk service, import serokell-nix.lib.systemd.hardenServices.